### PR TITLE
Fix metric provenance and risk-free rate handling

### DIFF
--- a/components/performance-charts/rolling-metrics-chart.tsx
+++ b/components/performance-charts/rolling-metrics-chart.tsx
@@ -17,7 +17,7 @@ interface RollingMetricsChartProps {
   className?: string;
 }
 
-type MetricType = "win_rate" | "profit_factor" | "sharpe";
+type MetricType = "win_rate" | "profit_factor" | "pl_signal_to_noise";
 
 const METRIC_CONFIG = {
   win_rate: {
@@ -32,10 +32,10 @@ const METRIC_CONFIG = {
     yAxisLabel: "Profit Factor",
     format: (val: number) => val.toFixed(2),
   },
-  sharpe: {
-    key: "sharpeRatio" as const,
-    label: "Sharpe Ratio",
-    yAxisLabel: "Sharpe Ratio",
+  pl_signal_to_noise: {
+    key: "plSignalToNoise" as const,
+    label: "P/L Signal-to-Noise",
+    yAxisLabel: "Mean Trade P/L / P/L Volatility (Nonannualized)",
     format: (val: number) => val.toFixed(2),
   },
 };
@@ -88,7 +88,7 @@ export function RollingMetricsChart({ className }: RollingMetricsChartProps) {
     flavor:
       "Your building progress through a moving window - examining your last 30 blocks at each construction milestone.",
     detailed:
-      "Rolling calculations show how your performance metrics evolve using moving time windows, giving you a dynamic view of improvement or deterioration. This is more responsive than looking at all-time statistics and helps identify when your trading effectiveness is trending up or down.",
+      "Rolling calculations show how your performance metrics evolve using moving time windows. P/L Signal-to-Noise is the nonannualized mean trade P/L divided by population P/L volatility; it is not the portfolio Sharpe ratio.",
   };
 
   if (!data || !data.rollingMetrics || data.rollingMetrics.length === 0) {
@@ -126,7 +126,7 @@ export function RollingMetricsChart({ className }: RollingMetricsChartProps) {
           <SelectContent>
             <SelectItem value="win_rate">Win Rate</SelectItem>
             <SelectItem value="profit_factor">Profit Factor</SelectItem>
-            <SelectItem value="sharpe">Sharpe Ratio</SelectItem>
+            <SelectItem value="pl_signal_to_noise">P/L Signal-to-Noise</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,7 @@ This document explains how TradeBlocks is structured and how to work effectively
 
 ### Calculations & Utilities
 
-- `packages/lib/calculations/portfolio-stats.ts` – Computes win rates, drawdowns, expectancy, and normalized metrics. Uses Math.js to mirror the legacy Python implementation (sample standard deviation on Sharpe, population on Sortino).
+- `packages/lib/calculations/portfolio-stats.ts` – Computes win rates, drawdowns, expectancy, and normalized metrics. Sharpe uses sample standard deviation (N-1), annualizes daily excess returns by 252, and defaults to historical FRED DTB3 rates. `AnalysisConfig.riskFreeRateAnnualPct` can supply a fixed annual percentage instead.
 - `packages/lib/calculations/risk/` – Monte Carlo simulation helpers powering the risk simulator.
 - `packages/lib/processing/trade-processor.ts` & `daily-log-processor.ts` – Convert raw CSV strings into typed models, handling alias headers and data validation (`packages/lib/models/validators.ts`).
 - `packages/lib/utils/date.ts`, `packages/lib/utils/number.ts` – Reusable formatting helpers.
@@ -73,6 +73,7 @@ This document explains how TradeBlocks is structured and how to work effectively
 
 - Expected headers match OptionOmega exports (`packages/lib/models/trade.ts`). Key columns:
   - `Date Opened`, `Time Opened`, `Legs`, `P/L`, `Strategy`
+  - Option Omega `P/L` is already net of its commission and fee columns. CSV ingestion stamps `plBasis: "net_includes_fees"` so fees remain available for attribution without being deducted twice.
   - `Opening Commissions + Fees`, `Closing Commissions + Fees`
   - Ratio columns such as `Opening Short/Long Ratio` are optional but supported.
 - Aliases in `TRADE_COLUMN_ALIASES` normalize variants (e.g., `Opening comms & fees`).

--- a/packages/lib/calculations/enrich-trades.ts
+++ b/packages/lib/calculations/enrich-trades.ts
@@ -16,6 +16,7 @@ import {
   type EquityCurvePoint,
   type ExposureAtOpen,
 } from "./daily-exposure.ts";
+import { getNetPl } from "../utils/equity-curve.ts";
 
 /**
  * Static dataset with its rows for matching
@@ -150,7 +151,7 @@ function enrichSingleTrade(
   exposureAtOpen?: ExposureAtOpen,
 ): EnrichedTrade {
   const totalFees = trade.openingCommissionsFees + (trade.closingCommissionsFees ?? 0);
-  const netPl = trade.pl - totalFees;
+  const netPl = getNetPl(trade);
 
   // VIX changes
   const hasVixData = trade.openingVix != null && trade.closingVix != null;

--- a/packages/lib/calculations/monte-carlo.ts
+++ b/packages/lib/calculations/monte-carlo.ts
@@ -5,7 +5,7 @@
  * and calculate risk metrics like Value at Risk (VaR) and maximum drawdown distributions.
  */
 
-import type { Trade } from "../models/trade.ts";
+import { PlBasis, type Trade } from "../models/trade.ts";
 
 /**
  * Parameters for Monte Carlo simulation
@@ -418,7 +418,7 @@ export function createSyntheticMaxLossTrades(
         avgClosingCost: 0,
         reasonForClose,
         pl: -maxAbsoluteLoss,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
         numContracts: avgContracts,
         fundsAtClose: 0,
         marginReq: maxAbsoluteLoss,

--- a/packages/lib/calculations/monte-carlo.ts
+++ b/packages/lib/calculations/monte-carlo.ts
@@ -418,6 +418,7 @@ export function createSyntheticMaxLossTrades(
         avgClosingCost: 0,
         reasonForClose,
         pl: -maxAbsoluteLoss,
+        plBasis: "net_includes_fees",
         numContracts: avgContracts,
         fundsAtClose: 0,
         marginReq: maxAbsoluteLoss,

--- a/packages/lib/calculations/performance.ts
+++ b/packages/lib/calculations/performance.ts
@@ -7,8 +7,12 @@
 
 import type { Trade } from "../models/trade.ts";
 import type { DailyLogEntry } from "../models/daily-log.ts";
-import type { PerformanceMetrics, TimePeriod } from "../models/portfolio-stats.ts";
-import { getRiskFreeRateByKey } from "../utils/risk-free-rate.ts";
+import type {
+  PerformanceMetrics,
+  TimePeriod,
+  PortfolioCalculationMethodology,
+} from "../models/portfolio-stats.ts";
+import { PortfolioStatsCalculator } from "./portfolio-stats.ts";
 
 /**
  * Performance calculator for chart data and visualizations
@@ -215,47 +219,64 @@ export class PerformanceCalculator {
   }
 
   /**
-   * Calculate rolling Sharpe ratio using date-based Treasury rates
+   * Calculate rolling Sharpe over N distinct realized-trade dates.
+   *
+   * The canonical calculator inserts zero-P/L weekdays between the first and
+   * last realized date in each window, so the actual return-observation count
+   * is disclosed in calculationMethodology. This parameter is not a count of
+   * calendar or business-day observations.
    */
   static calculateRollingSharpe(
     trades: Trade[],
-    windowDays: number = 30,
-  ): Array<{ date: string; sharpe: number }> {
+    windowRealizedDates: number = 30,
+    riskFreeRateAnnualPct?: number,
+  ): Array<{
+    date: string;
+    sharpe: number | null;
+    windowDefinition: "distinct_realized_trade_dates";
+    requestedWindowSize: number;
+    calculationMethodology: PortfolioCalculationMethodology;
+  }> {
     if (trades.length === 0) return [];
 
-    const dailyPl = this.aggregatePLByPeriod(trades, "daily");
-    const sortedDates = Object.keys(dailyPl).sort();
+    const tradesByRealizedDate = new Map<string, Trade[]>();
+    for (const trade of trades) {
+      const date = new Date(trade.dateClosed ?? trade.dateOpened);
+      const dateKey = this.getDateKey(date, "daily");
+      const existing = tradesByRealizedDate.get(dateKey) ?? [];
+      existing.push(trade);
+      tradesByRealizedDate.set(dateKey, existing);
+    }
+    const sortedDates = [...tradesByRealizedDate.keys()].sort();
 
-    if (sortedDates.length < windowDays) return [];
+    if (sortedDates.length < windowRealizedDates) return [];
 
-    const result: Array<{ date: string; sharpe: number }> = [];
+    const calculator = new PortfolioStatsCalculator({
+      riskFreeRateAnnualPct,
+    });
+    const result: Array<{
+      date: string;
+      sharpe: number | null;
+      windowDefinition: "distinct_realized_trade_dates";
+      requestedWindowSize: number;
+      calculationMethodology: PortfolioCalculationMethodology;
+    }> = [];
 
-    for (let i = windowDays - 1; i < sortedDates.length; i++) {
-      const windowDates = sortedDates.slice(i - windowDays + 1, i + 1);
-      const windowReturns = windowDates.map((date) => dailyPl[date]);
-
-      // Calculate average excess returns using date-based Treasury rates
-      // Use getRiskFreeRateByKey to avoid UTC parsing issues with YYYY-MM-DD strings
-      const excessReturns = windowDates.map((date, idx) => {
-        const annualRate = getRiskFreeRateByKey(date); // Returns annual % (e.g., 4.32)
-        const dailyRiskFreeRate = annualRate / 100 / 252;
-        return windowReturns[idx] - dailyRiskFreeRate;
-      });
-
-      const avgExcessReturn =
-        excessReturns.reduce((sum, ret) => sum + ret, 0) / excessReturns.length;
-      // Use std of excess returns (not raw returns) for consistency with date-varying rates
-      const avgExcess = avgExcessReturn;
-      const excessVariance =
-        excessReturns.reduce((sum, ret) => sum + Math.pow(ret - avgExcess, 2), 0) /
-        (excessReturns.length - 1);
-      const stdDev = Math.sqrt(excessVariance);
-
-      const sharpe = stdDev > 0 ? (avgExcessReturn / stdDev) * Math.sqrt(252) : 0;
+    for (let i = windowRealizedDates - 1; i < sortedDates.length; i++) {
+      const windowDates = sortedDates.slice(i - windowRealizedDates + 1, i + 1);
+      const windowTrades = windowDates.flatMap((date) => tradesByRealizedDate.get(date) ?? []);
+      const stats = calculator.calculatePortfolioStats(windowTrades, undefined, true);
+      const calculationMethodology = calculator.getCalculationMethodology(windowTrades);
+      calculationMethodology.warnings.push(
+        `Rolling window is ${windowRealizedDates} distinct realized-trade dates, not ${windowRealizedDates} calendar or business days.`,
+      );
 
       result.push({
         date: sortedDates[i],
-        sharpe,
+        sharpe: stats.sharpeRatio ?? null,
+        windowDefinition: "distinct_realized_trade_dates",
+        requestedWindowSize: windowRealizedDates,
+        calculationMethodology,
       });
     }
 

--- a/packages/lib/calculations/period-segmentation.ts
+++ b/packages/lib/calculations/period-segmentation.ts
@@ -50,9 +50,9 @@ export interface PeriodMetrics {
   sharpeRatio: number | null;
   /** Average monthly return as a percentage of equity */
   avgMonthlyReturnPct: number;
-  /** Net P&L (gross P&L minus commissions) */
+  /** Net P&L with fees deducted exactly once according to source basis */
   netPl: number;
-  /** Gross P&L */
+  /** Reported source P&L (`Trade.pl`) */
   totalPl: number;
   /** Total commissions (opening + closing) */
   totalCommissions: number;

--- a/packages/lib/calculations/portfolio-stats.ts
+++ b/packages/lib/calculations/portfolio-stats.ts
@@ -6,7 +6,7 @@
  * Uses math.js for statistical calculations to ensure numpy compatibility.
  *
  * Key improvements for consistency:
- * - Sharpe Ratio: Uses sample std (N-1) via math.js 'uncorrected' parameter
+ * - Sharpe Ratio: Uses sample std (N-1) via math.js 'unbiased' parameter
  * - Sortino Ratio: Uses standard downside deviation = sqrt((1/N) * sum(min(excess_i, 0)^2))
  *   where N = total observations (RMS of negative excess returns from zero, not std of negatives)
  * - Mean calculations: Replaced manual reduce operations with math.js mean()
@@ -19,10 +19,21 @@
 import { std, mean, min, max } from "mathjs";
 import type { Trade } from "../models/trade.ts";
 import type { DailyLogEntry } from "../models/daily-log.ts";
-import type { PortfolioStats, StrategyStats, AnalysisConfig } from "../models/portfolio-stats.ts";
+import type {
+  PortfolioStats,
+  StrategyStats,
+  AnalysisConfig,
+  PortfolioCalculationMethodology,
+} from "../models/portfolio-stats.ts";
 import type { NormalizedPortfolioStats } from "../models/portfolio-stats-normalized.ts";
 import { asDecimal01 } from "../types/percentage.ts";
-import { getRiskFreeRate } from "../utils/risk-free-rate.ts";
+import {
+  formatDateToKey,
+  getLatestRateDate,
+  getRiskFreeRate,
+  resolveTreasuryRateByKey,
+} from "../utils/risk-free-rate.ts";
+import { getNetPl } from "../utils/equity-curve.ts";
 
 /**
  * Daily return with associated date for date-based risk-free rate calculations.
@@ -31,6 +42,10 @@ import { getRiskFreeRate } from "../utils/risk-free-rate.ts";
 interface DailyReturnWithDate {
   date: Date;
   return: number;
+}
+
+function getMetricPl(trade: Trade): number {
+  return getNetPl(trade);
 }
 
 /**
@@ -51,6 +66,13 @@ export class PortfolioStatsCalculator {
 
   constructor(config: Partial<AnalysisConfig> = {}) {
     this.config = { ...DEFAULT_ANALYSIS_CONFIG, ...config };
+    const fixedRate = this.config.riskFreeRateAnnualPct;
+    if (
+      fixedRate !== undefined &&
+      (!Number.isFinite(fixedRate) || fixedRate <= -100 || fixedRate > 100)
+    ) {
+      throw new RangeError("riskFreeRateAnnualPct must be greater than -100 and at most 100");
+    }
   }
 
   /**
@@ -73,7 +95,7 @@ export class PortfolioStatsCalculator {
         if (!trade.dateOpened) return false;
 
         // Validate date
-        const date = new Date(trade.dateOpened);
+        const date = new Date(trade.dateClosed ?? trade.dateOpened);
         if (isNaN(date.getTime())) return false;
 
         // Check commissions
@@ -98,7 +120,13 @@ export class PortfolioStatsCalculator {
       ? undefined // Force trade-based calculations for strategy filtering
       : dailyLogEntries;
 
-    // Debug logging removed for tests
+    // Derived metrics always use net-after-fee P/L. The original reported P/L
+    // remains available separately as totalPl.
+    const metricTrades = validTrades.map((trade) => ({
+      ...trade,
+      pl: getMetricPl(trade),
+      plBasis: "net_includes_fees" as const,
+    }));
 
     // Basic statistics
     const totalTrades = validTrades.length;
@@ -107,12 +135,12 @@ export class PortfolioStatsCalculator {
       (sum, trade) => sum + trade.openingCommissionsFees + trade.closingCommissionsFees,
       0,
     );
-    const netPl = totalPl - totalCommissions;
+    const netPl = validTrades.reduce((sum, trade) => sum + getNetPl(trade), 0);
 
     // Win/Loss analysis
-    const winningTradesList = validTrades.filter((trade) => trade.pl > 0);
-    const losingTradesList = validTrades.filter((trade) => trade.pl < 0);
-    const breakEvenTradesList = validTrades.filter((trade) => trade.pl === 0);
+    const winningTradesList = metricTrades.filter((trade) => trade.pl > 0);
+    const losingTradesList = metricTrades.filter((trade) => trade.pl < 0);
+    const breakEvenTradesList = metricTrades.filter((trade) => trade.pl === 0);
 
     const winRate = winningTradesList.length / totalTrades;
     const avgWin =
@@ -123,7 +151,7 @@ export class PortfolioStatsCalculator {
       losingTradesList.length > 0 ? (mean(losingTradesList.map((trade) => trade.pl)) as number) : 0;
 
     // Max win/loss - handle empty arrays
-    const plValues = validTrades
+    const plValues = metricTrades
       .map((trade) => trade.pl)
       .filter((pl) => typeof pl === "number" && !isNaN(pl));
     const maxWin =
@@ -141,28 +169,28 @@ export class PortfolioStatsCalculator {
     const profitFactor = grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Infinity : 0;
 
     // Drawdown calculation
-    const maxDrawdown = this.calculateMaxDrawdown(validTrades, adjustedDailyLogs);
+    const maxDrawdown = this.calculateMaxDrawdown(metricTrades, adjustedDailyLogs);
 
     // Daily P/L calculation
-    const avgDailyPl = this.calculateAvgDailyPl(validTrades, adjustedDailyLogs);
+    const avgDailyPl = this.calculateAvgDailyPl(metricTrades, adjustedDailyLogs);
 
     // Sharpe ratio (if we have daily data)
-    const sharpeRatio = this.calculateSharpeRatio(validTrades, adjustedDailyLogs);
+    const sharpeRatio = this.calculateSharpeRatio(metricTrades, adjustedDailyLogs);
 
     // Advanced metrics
-    const cagr = this.calculateCAGR(validTrades);
-    const sortinoRatio = this.calculateSortinoRatio(validTrades, adjustedDailyLogs);
-    const calmarRatio = this.calculateCalmarRatio(validTrades, adjustedDailyLogs);
-    const kellyPercentage = this.calculateKellyPercentage(validTrades);
+    const cagr = this.calculateCAGR(metricTrades);
+    const sortinoRatio = this.calculateSortinoRatio(metricTrades, adjustedDailyLogs);
+    const calmarRatio = this.calculateCalmarRatio(metricTrades, adjustedDailyLogs);
+    const kellyPercentage = this.calculateKellyPercentage(metricTrades);
 
     // Streak calculations
-    const streaks = this.calculateStreaks(validTrades);
+    const streaks = this.calculateStreaks(metricTrades);
 
     // Time in drawdown
-    const timeInDrawdown = this.calculateTimeInDrawdown(validTrades, adjustedDailyLogs);
+    const timeInDrawdown = this.calculateTimeInDrawdown(metricTrades, adjustedDailyLogs);
 
     // Periodic win rates
-    const periodicWinRates = this.calculatePeriodicWinRates(validTrades);
+    const periodicWinRates = this.calculatePeriodicWinRates(metricTrades);
 
     // Calculate initial capital (prefer daily logs when available)
     const initialCapital = PortfolioStatsCalculator.calculateInitialCapital(
@@ -358,7 +386,7 @@ export class PortfolioStatsCalculator {
 
     trades.forEach((trade) => {
       try {
-        const date = new Date(trade.dateOpened);
+        const date = new Date(trade.dateClosed ?? trade.dateOpened);
         if (!isNaN(date.getTime())) {
           const dateKey = date.toISOString().split("T")[0];
           const currentPl = dailyPl.get(dateKey) || 0;
@@ -398,7 +426,7 @@ export class PortfolioStatsCalculator {
 
     for (const { date, return: dailyReturn } of dailyReturnsWithDates) {
       // Get the actual Treasury rate for this specific date
-      const annualRate = getRiskFreeRate(date); // Returns annual % (e.g., 4.32 for 4.32%)
+      const annualRate = this.getAnnualRiskFreeRatePct(date);
       const dailyRiskFreeRate = annualRate / 100 / this.config.annualizationFactor;
 
       excessReturns.push(dailyReturn - dailyRiskFreeRate);
@@ -408,7 +436,7 @@ export class PortfolioStatsCalculator {
     // With date-varying risk-free rates, we must use std of excess returns (not raw returns)
     // because std(rawReturns) != std(excessReturns) when rates change materially
     const avgExcessReturn = mean(excessReturns) as number;
-    const stdDev = std(excessReturns, "uncorrected") as number; // Use sample std (N-1) of excess returns
+    const stdDev = std(excessReturns, "unbiased") as number;
 
     if (stdDev === 0) return undefined;
 
@@ -498,7 +526,7 @@ export class PortfolioStatsCalculator {
 
     for (const { date, return: dailyReturn } of dailyReturnsWithDates) {
       // Get the actual Treasury rate for this specific date
-      const annualRate = getRiskFreeRate(date); // Returns annual % (e.g., 4.32 for 4.32%)
+      const annualRate = this.getAnnualRiskFreeRatePct(date);
       const dailyRiskFreeRate = annualRate / 100 / this.config.annualizationFactor;
 
       excessReturns.push(dailyReturn - dailyRiskFreeRate);
@@ -771,8 +799,16 @@ export class PortfolioStatsCalculator {
 
     // Calculate from trade data
     const sortedTrades = [...trades].sort((a, b) => {
-      const dateCompare = new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime();
+      const dateCompare =
+        new Date(a.dateClosed ?? a.dateOpened).getTime() -
+        new Date(b.dateClosed ?? b.dateOpened).getTime();
       if (dateCompare !== 0) return dateCompare;
+      const closeTimeCompare = (a.timeClosed ?? a.timeOpened).localeCompare(
+        b.timeClosed ?? b.timeOpened,
+      );
+      if (closeTimeCompare !== 0) return closeTimeCompare;
+      const openDateCompare = new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime();
+      if (openDateCompare !== 0) return openDateCompare;
       return a.timeOpened.localeCompare(b.timeOpened);
     });
 
@@ -781,7 +817,7 @@ export class PortfolioStatsCalculator {
 
     // Group trades by date
     for (const trade of sortedTrades) {
-      const tradeDate = new Date(trade.dateOpened);
+      const tradeDate = new Date(trade.dateClosed ?? trade.dateOpened);
       const dateKey = tradeDate.toISOString().split("T")[0];
       if (!tradesByDate.has(dateKey)) {
         tradesByDate.set(dateKey, { date: tradeDate, trades: [] });
@@ -789,26 +825,156 @@ export class PortfolioStatsCalculator {
       tradesByDate.get(dateKey)!.trades.push(trade);
     }
 
-    // Calculate daily returns with dates
+    // Calculate daily returns with dates. A Sharpe annualized by 252 must use
+    // a business-day series, not a sparse series containing only trade exits.
     const initialCapital = PortfolioStatsCalculator.calculateInitialCapital(trades);
     let portfolioValue = initialCapital;
 
-    // Sort by date key to ensure chronological order
     const sortedDateKeys = Array.from(tradesByDate.keys()).sort();
+    if (sortedDateKeys.length === 0) return [];
+    const parseDateKey = (key: string): Date => {
+      const [year, month, day] = key.split("-").map(Number);
+      return new Date(year, month - 1, day);
+    };
+    const cursor = parseDateKey(sortedDateKeys[0]);
+    const endDate = parseDateKey(sortedDateKeys[sortedDateKeys.length - 1]);
 
-    for (const dateKey of sortedDateKeys) {
-      const { date, trades: dayTrades } = tradesByDate.get(dateKey)!;
+    while (cursor <= endDate) {
+      const dateKey = formatDateToKey(cursor);
+      const dayTrades = tradesByDate.get(dateKey)?.trades ?? [];
+      const isWeekend = cursor.getDay() === 0 || cursor.getDay() === 6;
+      const includeDate = !this.config.useBusinessDaysOnly || !isWeekend || dayTrades.length > 0;
+      if (!includeDate) {
+        cursor.setDate(cursor.getDate() + 1);
+        continue;
+      }
       const dayPl = dayTrades.reduce((sum, trade) => sum + trade.pl, 0);
       if (portfolioValue > 0) {
         dailyReturns.push({
-          date,
+          date: new Date(cursor),
           return: dayPl / portfolioValue,
         });
         portfolioValue += dayPl;
       }
+      cursor.setDate(cursor.getDate() + 1);
     }
 
     return dailyReturns;
+  }
+
+  /**
+   * Return the exact methodology used by risk-adjusted-return and net P/L calculations.
+   * MCP consumers can use this instead of inferring semantics from metric names.
+   */
+  getCalculationMethodology(
+    trades: Trade[],
+    dailyLogEntries?: DailyLogEntry[],
+  ): PortfolioCalculationMethodology {
+    const returns = this.calculateDailyReturnsWithDates(trades, dailyLogEntries);
+    const basisCounts = {
+      netIncludesFees: trades.filter((trade) => trade.plBasis === "net_includes_fees").length,
+      grossBeforeFees: trades.filter((trade) => trade.plBasis === "gross_before_fees").length,
+      undeclaredAssumedGross: trades.filter((trade) => trade.plBasis === undefined).length,
+    };
+    const basisKinds = [
+      basisCounts.netIncludesFees > 0,
+      basisCounts.grossBeforeFees > 0,
+      basisCounts.undeclaredAssumedGross > 0,
+    ].filter(Boolean).length;
+    const sourceBasis: PortfolioCalculationMethodology["pnl"]["sourceBasis"] =
+      basisKinds > 1
+        ? "mixed"
+        : basisCounts.netIncludesFees > 0
+          ? "net_includes_fees"
+          : basisCounts.grossBeforeFees > 0
+            ? "gross_before_fees"
+            : "undeclared_assumed_gross";
+    const feeHandling: PortfolioCalculationMethodology["pnl"]["feeHandling"] =
+      basisKinds > 1
+        ? "mixed"
+        : basisCounts.netIncludesFees > 0
+          ? "already_included"
+          : "deducted_once";
+
+    const dateKeys = returns.map(({ date }) => formatDateToKey(date)).sort();
+    const fixedRate = this.config.riskFreeRateAnnualPct;
+    let riskFreeRate: PortfolioCalculationMethodology["sharpe"]["riskFreeRate"];
+    if (fixedRate !== undefined) {
+      riskFreeRate = { mode: "fixed", annualRatePct: fixedRate };
+    } else {
+      const resolutionCounts = {
+        exact: 0,
+        prior: 0,
+        clampedEarliest: 0,
+        staleAfterLatest: 0,
+      };
+      for (const dateKey of dateKeys) {
+        const resolution = resolveTreasuryRateByKey(dateKey).resolution;
+        if (resolution === "exact") resolutionCounts.exact++;
+        if (resolution === "prior") resolutionCounts.prior++;
+        if (resolution === "clamped-earliest") resolutionCounts.clampedEarliest++;
+        if (resolution === "stale-after-latest") resolutionCounts.staleAfterLatest++;
+      }
+      riskFreeRate = {
+        mode: "historical",
+        series: "FRED_DTB3",
+        dataThrough: formatDateToKey(getLatestRateDate()),
+        resolutionCounts,
+      };
+    }
+
+    const usesDailyLog = !!dailyLogEntries?.length;
+    const warnings: string[] = [];
+    if (!usesDailyLog) {
+      warnings.push(
+        `No daily log was available; realized trade P/L is grouped by close date and zero-P/L ${this.config.useBusinessDaysOnly ? "weekdays" : "calendar days"} are inserted. Exchange holidays are not modeled.`,
+      );
+    }
+    if (riskFreeRate.mode === "historical" && riskFreeRate.resolutionCounts.staleAfterLatest > 0) {
+      warnings.push(
+        `${riskFreeRate.resolutionCounts.staleAfterLatest} return observations use the latest available DTB3 rate after ${riskFreeRate.dataThrough}.`,
+      );
+    }
+
+    return {
+      pnl: {
+        netPlBasis: "net_after_fees",
+        sourceBasis,
+        feeHandling,
+        basisCounts,
+      },
+      returns: {
+        source: usesDailyLog ? "daily_log" : "realized_trade_pl",
+        attribution: usesDailyLog ? "daily_log_date" : "date_closed_fallback_date_opened",
+        observations: returns.length,
+        dateRange: {
+          start: dateKeys[0] ?? null,
+          end: dateKeys[dateKeys.length - 1] ?? null,
+        },
+        idleDays: usesDailyLog
+          ? "included_as_provided"
+          : this.config.useBusinessDaysOnly
+            ? "included_business_days"
+            : "included_calendar_days",
+      },
+      sharpe: {
+        annualizationFactor: this.config.annualizationFactor,
+        volatilityEstimator: "sample_standard_deviation_n_minus_1",
+        riskFreeRate,
+      },
+      sortino: {
+        annualizationFactor: this.config.annualizationFactor,
+        downsideTarget: "zero_excess_return",
+        observationSet: "all_return_observations_positive_values_contribute_zero",
+        denominator: "total_observations_n",
+        riskFreeRate: "same_daily_rate_as_sharpe",
+      },
+      warnings,
+    };
+  }
+
+  private getAnnualRiskFreeRatePct(date: Date): number {
+    return this.config.riskFreeRateAnnualPct ?? getRiskFreeRate(date);
   }
 
   /**
@@ -873,13 +1039,23 @@ export class PortfolioStatsCalculator {
     // Fall back to trade-based calculation
     // Sort trades chronologically
     const sortedTrades = [...trades].sort((a, b) => {
-      const dateCompare = new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime();
+      const dateCompare =
+        new Date(a.dateClosed ?? a.dateOpened).getTime() -
+        new Date(b.dateClosed ?? b.dateOpened).getTime();
       if (dateCompare !== 0) return dateCompare;
+      const closeTimeCompare = (a.timeClosed ?? a.timeOpened).localeCompare(
+        b.timeClosed ?? b.timeOpened,
+      );
+      if (closeTimeCompare !== 0) return closeTimeCompare;
+      const openDateCompare = new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime();
+      if (openDateCompare !== 0) return openDateCompare;
       return a.timeOpened.localeCompare(b.timeOpened);
     });
 
     const firstTrade = sortedTrades[0];
-    return firstTrade.fundsAtClose - firstTrade.pl;
+    const capitalBasisPl =
+      firstTrade.plBasis === undefined ? firstTrade.pl : getMetricPl(firstTrade);
+    return firstTrade.fundsAtClose - capitalBasisPl;
   }
 
   /**
@@ -895,11 +1071,11 @@ export class PortfolioStatsCalculator {
     }
 
     const relevantTrades = trades.filter((trade) => {
-      const tradeDate = new Date(trade.dateOpened);
+      const tradeDate = new Date(trade.dateClosed ?? trade.dateOpened);
       return tradeDate <= targetDate;
     });
 
-    const totalPl = relevantTrades.reduce((sum, trade) => sum + trade.pl, 0);
+    const totalPl = relevantTrades.reduce((sum, trade) => sum + getMetricPl(trade), 0);
     return initialCapital + totalPl;
   }
 }

--- a/packages/lib/calculations/portfolio-stats.ts
+++ b/packages/lib/calculations/portfolio-stats.ts
@@ -17,7 +17,7 @@
  */
 
 import { std, mean, min, max } from "mathjs";
-import type { Trade } from "../models/trade.ts";
+import { PlBasis, type Trade } from "../models/trade.ts";
 import type { DailyLogEntry } from "../models/daily-log.ts";
 import type {
   PortfolioStats,
@@ -125,7 +125,7 @@ export class PortfolioStatsCalculator {
     const metricTrades = validTrades.map((trade) => ({
       ...trade,
       pl: getMetricPl(trade),
-      plBasis: "net_includes_fees" as const,
+      plBasis: PlBasis.NetIncludesFees,
     }));
 
     // Basic statistics
@@ -872,8 +872,8 @@ export class PortfolioStatsCalculator {
   ): PortfolioCalculationMethodology {
     const returns = this.calculateDailyReturnsWithDates(trades, dailyLogEntries);
     const basisCounts = {
-      netIncludesFees: trades.filter((trade) => trade.plBasis === "net_includes_fees").length,
-      grossBeforeFees: trades.filter((trade) => trade.plBasis === "gross_before_fees").length,
+      netIncludesFees: trades.filter((trade) => trade.plBasis === PlBasis.NetIncludesFees).length,
+      grossBeforeFees: trades.filter((trade) => trade.plBasis === PlBasis.GrossBeforeFees).length,
       undeclaredAssumedGross: trades.filter((trade) => trade.plBasis === undefined).length,
     };
     const basisKinds = [

--- a/packages/lib/calculations/trade-cost-reconciliation.ts
+++ b/packages/lib/calculations/trade-cost-reconciliation.ts
@@ -7,6 +7,7 @@
 
 import type { ReportingTrade } from "../models/reporting-trade.ts";
 import type { Trade } from "../models/trade.ts";
+import { getGrossPl, getNetPl } from "../utils/equity-curve.ts";
 
 export type TradeCostScaling = "perContract" | "toActualContracts";
 
@@ -103,9 +104,9 @@ function isFiniteNumber(value: unknown): value is number {
 /**
  * Decompose model-vs-live P/L for a pair that the caller has already matched.
  *
- * Trade.pl is the model's gross P/L (the same invariant used by enrichTrades),
- * so model net is gross minus recorded commissions/fees. Actual gross is
- * reconstructed from the reporting log's opening premium and average closing cost:
+ * Model gross and net P/L are resolved from Trade.plBasis, so commissions are
+ * applied exactly once. Actual gross is reconstructed from the reporting log's
+ * opening premium and average closing cost:
  * `(initialPremium + avgClosingCost) * contracts * 100`.
  */
 export function reconcileTradeCosts(
@@ -199,9 +200,9 @@ export function reconcileTradeCosts(
     basis === "perContract" ? 1 / model.numContracts : actual.numContracts / model.numContracts;
   const actualScaleFactor = basis === "perContract" ? 1 / actual.numContracts : 1;
 
-  const modelGross = model.pl * modelScaleFactor;
+  const modelGross = getGrossPl(model) * modelScaleFactor;
   const modelFees = modelFeesTotal * modelScaleFactor;
-  const modelNet = modelGross - modelFees;
+  const modelNet = getNetPl(model) * modelScaleFactor;
   const actualGross = actualGrossTotal * actualScaleFactor;
   const actualFees = actualFeesTotal * actualScaleFactor;
   const actualNet = actual.pl * actualScaleFactor;

--- a/packages/lib/calculations/walk-forward-analyzer.ts
+++ b/packages/lib/calculations/walk-forward-analyzer.ts
@@ -24,6 +24,7 @@ import {
 } from "./correlation.ts";
 import { performTailRiskAnalysis } from "./tail-risk-analysis.ts";
 import type { TailRiskAnalysisOptions } from "../models/tail-risk.ts";
+import { getNetPl } from "../utils/equity-curve.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_MIN_IN_SAMPLE_TRADES = 10;
@@ -499,19 +500,28 @@ export class WalkForwardAnalyzer {
 
       const scale = positionMultiplier * strategyWeight;
       const scaledPl = trade.pl * scale;
+      const scaledOpeningCommissions = trade.openingCommissionsFees * Math.abs(scale);
+      const scaledClosingCommissions = trade.closingCommissionsFees * Math.abs(scale);
+      const scaledNetPl = getNetPl({
+        pl: scaledPl,
+        plBasis: trade.plBasis,
+        openingCommissionsFees: scaledOpeningCommissions,
+        closingCommissionsFees: scaledClosingCommissions,
+      });
 
-      runningEquity += scaledPl;
+      runningEquity += scaledNetPl;
 
       // Only include fields used by PortfolioStatsCalculator to reduce object copy overhead
       scaledTrades.push({
         pl: scaledPl,
+        plBasis: trade.plBasis,
         dateOpened: trade.dateOpened,
         timeOpened: trade.timeOpened,
         dateClosed: trade.dateClosed,
         timeClosed: trade.timeClosed,
         fundsAtClose: runningEquity,
-        openingCommissionsFees: trade.openingCommissionsFees * Math.abs(scale),
-        closingCommissionsFees: trade.closingCommissionsFees * Math.abs(scale),
+        openingCommissionsFees: scaledOpeningCommissions,
+        closingCommissionsFees: scaledClosingCommissions,
         strategy: trade.strategy,
       } as Trade);
     }

--- a/packages/lib/models/portfolio-stats.ts
+++ b/packages/lib/models/portfolio-stats.ts
@@ -20,6 +20,7 @@
  */
 export interface PortfolioStats {
   totalTrades: number;
+  /** Sum of source-reported `Trade.pl` values in their declared basis. */
   totalPl: number;
   winningTrades: number;
   losingTrades: number;
@@ -48,6 +49,7 @@ export interface PortfolioStats {
   maxDrawdown: number;
   avgDailyPl: number;
   totalCommissions: number;
+  /** Basis-aware net P/L with commissions and fees deducted exactly once. */
   netPl: number;
   profitFactor: number;
   /** Starting portfolio value before any P/L */
@@ -111,6 +113,59 @@ export interface AnalysisConfig {
   annualizationFactor: number; // 252 for business days, 365 for calendar days
   confidenceLevel: number; // 0.95 for 95% confidence
   drawdownThreshold: number; // Minimum drawdown % to consider significant
+  /**
+   * Optional fixed annual risk-free rate in percentage points.
+   * Example: 2 means 2% annually. When omitted, historical FRED DTB3 rates are used.
+   */
+  riskFreeRateAnnualPct?: number;
+}
+
+export interface PortfolioCalculationMethodology {
+  pnl: {
+    netPlBasis: "net_after_fees";
+    sourceBasis: "net_includes_fees" | "gross_before_fees" | "mixed" | "undeclared_assumed_gross";
+    feeHandling: "already_included" | "deducted_once" | "mixed";
+    basisCounts: {
+      netIncludesFees: number;
+      grossBeforeFees: number;
+      undeclaredAssumedGross: number;
+    };
+  };
+  returns: {
+    source: "daily_log" | "realized_trade_pl";
+    attribution: "daily_log_date" | "date_closed_fallback_date_opened";
+    observations: number;
+    dateRange: { start: string | null; end: string | null };
+    idleDays: "included_as_provided" | "included_business_days" | "included_calendar_days";
+  };
+  sharpe: {
+    annualizationFactor: number;
+    volatilityEstimator: "sample_standard_deviation_n_minus_1";
+    riskFreeRate:
+      | {
+          mode: "fixed";
+          annualRatePct: number;
+        }
+      | {
+          mode: "historical";
+          series: "FRED_DTB3";
+          dataThrough: string;
+          resolutionCounts: {
+            exact: number;
+            prior: number;
+            clampedEarliest: number;
+            staleAfterLatest: number;
+          };
+        };
+  };
+  sortino: {
+    annualizationFactor: number;
+    downsideTarget: "zero_excess_return";
+    observationSet: "all_return_observations_positive_values_contribute_zero";
+    denominator: "total_observations_n";
+    riskFreeRate: "same_daily_rate_as_sharpe";
+  };
+  warnings: string[];
 }
 
 /**

--- a/packages/lib/models/report-config.ts
+++ b/packages/lib/models/report-config.ts
@@ -301,15 +301,15 @@ export const REPORT_FIELDS: FieldInfo[] = [
     label: "Profit/Loss",
     category: "returns",
     unit: "$",
-    description: "Trade profit or loss in dollars (before fees)",
+    description: "Trade profit or loss in the source-declared P/L basis",
   },
   {
     field: "netPl",
     label: "Net P/L",
     category: "returns",
     unit: "$",
-    description: "Profit/loss after subtracting all fees",
-    formula: "P/L - Total Fees",
+    description: "Profit/loss after fees, deducting recorded fees only when the source is gross",
+    formula: "basis-aware net P/L",
   },
   {
     field: "plPct",

--- a/packages/lib/models/trade.ts
+++ b/packages/lib/models/trade.ts
@@ -23,7 +23,15 @@ export interface Trade {
   reasonForClose?: string;
 
   // Financial metrics
-  pl: number; // Profit/Loss
+  pl: number; // Profit/Loss in the basis declared by plBasis
+  /**
+   * Declares whether `pl` already includes commissions and fees.
+   *
+   * Option Omega trade-log exports use `net_includes_fees`. Programmatic
+   * callers that omit this field retain the legacy TradeBlocks assumption
+   * that `pl` is gross and fees must be deducted once.
+   */
+  plBasis?: "net_includes_fees" | "gross_before_fees";
   numContracts: number;
   fundsAtClose: number;
   marginReq: number;

--- a/packages/lib/models/trade.ts
+++ b/packages/lib/models/trade.ts
@@ -2,6 +2,11 @@
  * Trade model based on legacy Python Trade class
  * Represents individual trade record from portfolio CSV
  */
+export enum PlBasis {
+  NetIncludesFees = "net_includes_fees",
+  GrossBeforeFees = "gross_before_fees",
+}
+
 export interface Trade {
   // Core trade identification
   dateOpened: Date;
@@ -31,7 +36,7 @@ export interface Trade {
    * callers that omit this field retain the legacy TradeBlocks assumption
    * that `pl` is gross and fees must be deducted once.
    */
-  plBasis?: "net_includes_fees" | "gross_before_fees";
+  plBasis?: PlBasis;
   numContracts: number;
   fundsAtClose: number;
   marginReq: number;

--- a/packages/lib/models/validators.ts
+++ b/packages/lib/models/validators.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PlBasis } from "./trade.ts";
 
 /**
  * Zod schema for validating raw trade data from CSV
@@ -54,7 +55,7 @@ export const tradeSchema = z.object({
   avgClosingCost: z.number().finite().optional(),
   reasonForClose: z.string().optional(),
   pl: z.number().finite(),
-  plBasis: z.enum(["net_includes_fees", "gross_before_fees"]).optional(),
+  plBasis: z.nativeEnum(PlBasis).optional(),
   numContracts: z.number().int().positive(),
   fundsAtClose: z.number().finite(),
   marginReq: z.number().finite().min(0),

--- a/packages/lib/models/validators.ts
+++ b/packages/lib/models/validators.ts
@@ -54,6 +54,7 @@ export const tradeSchema = z.object({
   avgClosingCost: z.number().finite().optional(),
   reasonForClose: z.string().optional(),
   pl: z.number().finite(),
+  plBasis: z.enum(["net_includes_fees", "gross_before_fees"]).optional(),
   numContracts: z.number().int().positive(),
   fundsAtClose: z.number().finite(),
   marginReq: z.number().finite().min(0),

--- a/packages/lib/processing/data-loader.ts
+++ b/packages/lib/processing/data-loader.ts
@@ -163,7 +163,12 @@ export class IndexedDBAdapter implements StorageAdapter {
     return storedTrades.map((storedTrade) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { blockId, id, ...trade } = storedTrade;
-      return trade as Trade;
+      // This store is populated by the Option Omega CSV loader. Rows written
+      // before plBasis was introduced need the same provenance as fresh imports.
+      return {
+        ...trade,
+        plBasis: trade.plBasis ?? "net_includes_fees",
+      } as Trade;
     });
   }
 
@@ -512,6 +517,7 @@ export class DataLoader {
             : undefined,
           reasonForClose: row["Reason For Close"] || undefined,
           pl: parseFloat(row["P/L"] || "0"),
+          plBasis: "net_includes_fees",
           numContracts: parseInt(row["No. of Contracts"] || "1"),
           fundsAtClose: parseFloat(row["Funds at Close"] || "0"),
           marginReq: parseFloat(row["Margin Req."] || "0"),

--- a/packages/lib/processing/data-loader.ts
+++ b/packages/lib/processing/data-loader.ts
@@ -6,7 +6,12 @@
  * Supports optional IndexedDB storage
  */
 
-import { type Trade, TRADE_COLUMN_ALIASES, REQUIRED_TRADE_COLUMNS } from "../models/trade.ts";
+import {
+  PlBasis,
+  type Trade,
+  TRADE_COLUMN_ALIASES,
+  REQUIRED_TRADE_COLUMNS,
+} from "../models/trade.ts";
 import type { DailyLogEntry } from "../models/daily-log.ts";
 import { assertRequiredHeaders, normalizeHeaders, parseCsvLine } from "../utils/csv-headers.ts";
 // Import ProcessingError from models to avoid duplicate definition
@@ -163,11 +168,15 @@ export class IndexedDBAdapter implements StorageAdapter {
     return storedTrades.map((storedTrade) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { blockId, id, ...trade } = storedTrade;
-      // This store is populated by the Option Omega CSV loader. Rows written
-      // before plBasis was introduced need the same provenance as fresh imports.
+      // Historical application rows in this IndexedDB store were populated by
+      // the Option Omega CSV loader. Rows written before plBasis was introduced
+      // therefore have the same net-includes-fees provenance as fresh imports.
+      // The legacy row stores no independent gross/net field from which a
+      // contradictory basis could be inferred, so do not guess from fee
+      // arithmetic.
       return {
         ...trade,
-        plBasis: trade.plBasis ?? "net_includes_fees",
+        plBasis: trade.plBasis ?? PlBasis.NetIncludesFees,
       } as Trade;
     });
   }
@@ -517,7 +526,7 @@ export class DataLoader {
             : undefined,
           reasonForClose: row["Reason For Close"] || undefined,
           pl: parseFloat(row["P/L"] || "0"),
-          plBasis: "net_includes_fees",
+          plBasis: PlBasis.NetIncludesFees,
           numContracts: parseInt(row["No. of Contracts"] || "1"),
           fundsAtClose: parseFloat(row["Funds at Close"] || "0"),
           marginReq: parseFloat(row["Margin Req."] || "0"),

--- a/packages/lib/processing/trade-processor.ts
+++ b/packages/lib/processing/trade-processor.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  PlBasis,
   type Trade,
   TRADE_COLUMN_ALIASES,
   REQUIRED_TRADE_COLUMNS,
@@ -418,7 +419,7 @@ export class TradeProcessor {
           : undefined,
         reasonForClose: rawData["Reason For Close"] || undefined,
         pl: parseNumber(rawData["P/L"], "P/L"),
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
         numContracts: Math.round(parseNumber(rawData["No. of Contracts"], "No. of Contracts")),
         fundsAtClose: parseNumber(rawData["Funds at Close"], "Funds at Close"),
         marginReq: parseNumber(rawData["Margin Req."], "Margin Req."),

--- a/packages/lib/processing/trade-processor.ts
+++ b/packages/lib/processing/trade-processor.ts
@@ -418,6 +418,7 @@ export class TradeProcessor {
           : undefined,
         reasonForClose: rawData["Reason For Close"] || undefined,
         pl: parseNumber(rawData["P/L"], "P/L"),
+        plBasis: "net_includes_fees",
         numContracts: Math.round(parseNumber(rawData["No. of Contracts"], "No. of Contracts")),
         fundsAtClose: parseNumber(rawData["Funds at Close"], "Funds at Close"),
         marginReq: parseNumber(rawData["Margin Req."], "Margin Req."),

--- a/packages/lib/services/calendar-data.ts
+++ b/packages/lib/services/calendar-data.ts
@@ -15,11 +15,12 @@ import type {
   CalendarDayData,
 } from "../stores/trading-calendar-store.ts";
 import { PortfolioStatsCalculator } from "../calculations/portfolio-stats.ts";
+import { getNetPl } from "../utils/equity-curve.ts";
+import { getRiskFreeRate } from "../utils/risk-free-rate.ts";
 
 /**
  * Configuration for risk metric calculations
  */
-const RISK_FREE_RATE = 2.0; // 2% annual
 const ANNUALIZATION_FACTOR = 252; // Business days
 
 /**
@@ -91,10 +92,7 @@ export function getActualPlPerContract(trade: ReportingTrade): number {
  */
 export function getBacktestPlPerContract(trade: Trade): number {
   if (trade.numContracts === 0) return 0;
-  const totalCommissions =
-    (trade.openingCommissionsFees ?? 0) + (trade.closingCommissionsFees ?? 0);
-  const netPl = trade.pl - totalCommissions;
-  return netPl / trade.numContracts;
+  return getNetPl(trade) / trade.numContracts;
 }
 
 // =============================================================================
@@ -1080,16 +1078,16 @@ export function calculateAdvancedMetrics(
  * Calculate advanced metrics from daily log entries
  */
 function calculateMetricsFromDailyLogs(filteredLogs: DailyLogEntry[]): AdvancedPerformanceMetrics {
-  // Calculate daily returns from net liquidity
-  const dailyReturns: number[] = [];
-  for (let i = 1; i < filteredLogs.length; i++) {
-    const prevValue = filteredLogs[i - 1].netLiquidity;
-    const currentValue = filteredLogs[i].netLiquidity;
-    if (prevValue > 0) {
-      const dailyReturn = (currentValue - prevValue) / prevValue;
-      dailyReturns.push(dailyReturn);
-    }
-  }
+  // Match PortfolioStatsCalculator: use each row's stated daily P/L divided by
+  // the portfolio value before that P/L, including zero-P/L observation rows.
+  const returnsWithDates = filteredLogs.map((entry) => {
+    const previousValue = entry.netLiquidity - entry.dailyPl;
+    return {
+      date: entry.date,
+      value: previousValue > 0 ? entry.dailyPl / previousValue : 0,
+    };
+  });
+  const dailyReturns = returnsWithDates.map(({ value }) => value);
 
   if (dailyReturns.length < 2) {
     return {
@@ -1105,17 +1103,16 @@ function calculateMetricsFromDailyLogs(filteredLogs: DailyLogEntry[]): AdvancedP
   }
 
   // Calculate Sharpe Ratio
-  const avgDailyReturn = mean(dailyReturns) as number;
-  const stdDev = std(dailyReturns, "uncorrected") as number;
-  const dailyRiskFreeRate = RISK_FREE_RATE / 100 / ANNUALIZATION_FACTOR;
-  const excessReturn = avgDailyReturn - dailyRiskFreeRate;
-  const sharpe = stdDev > 0 ? (excessReturn / stdDev) * Math.sqrt(ANNUALIZATION_FACTOR) : null;
+  const excessReturns = returnsWithDates.map(
+    ({ date, value }) => value - getRiskFreeRate(date) / 100 / ANNUALIZATION_FACTOR,
+  );
+  const avgExcessReturn = mean(excessReturns) as number;
+  const stdDev = std(excessReturns, "unbiased") as number;
+  const sharpe = stdDev > 0 ? (avgExcessReturn / stdDev) * Math.sqrt(ANNUALIZATION_FACTOR) : null;
 
   // Calculate Sortino Ratio
   // Downside deviation = sqrt( (1/N) * sum( min(excessReturn_i, 0)^2 ) )
   // Uses ALL N observations; positive excess returns contribute 0 to the sum.
-  const excessReturns = dailyReturns.map((ret) => ret - dailyRiskFreeRate);
-  const avgExcessReturn = mean(excessReturns) as number;
   const N = excessReturns.length;
   const sumSquaredDownside = excessReturns.reduce((sum, ret) => {
     const downside = Math.min(ret, 0);

--- a/packages/lib/services/performance-snapshot.ts
+++ b/packages/lib/services/performance-snapshot.ts
@@ -95,7 +95,11 @@ export interface SnapshotChartData {
   rollingMetrics: Array<{
     date: string;
     winRate: number;
+    /** Nonannualized mean trade P/L divided by population stddev of trade P/L. */
+    plSignalToNoise: number;
+    /** @deprecated Compatibility alias; this value is not a Sharpe ratio. */
     sharpeRatio: number;
+    metricMethodology: "nonannualized_trade_pl_mean_over_population_stddev";
     profitFactor: number;
     volatility: number;
   }>;
@@ -1093,12 +1097,14 @@ async function calculateRollingMetrics(trades: Trade[], signal?: AbortSignal) {
           ? 999
           : 0;
 
-    const sharpeRatio = volatility > 0 ? avgReturn / volatility : 0;
+    const plSignalToNoise = volatility > 0 ? avgReturn / volatility : 0;
 
     metrics.push({
       date: new Date(trades[i].dateOpened).toISOString(),
       winRate: winRate * 100,
-      sharpeRatio,
+      plSignalToNoise,
+      sharpeRatio: plSignalToNoise,
+      metricMethodology: "nonannualized_trade_pl_mean_over_population_stddev",
       profitFactor,
       volatility,
     });

--- a/packages/lib/utils/combine-leg-groups.ts
+++ b/packages/lib/utils/combine-leg-groups.ts
@@ -11,6 +11,7 @@
 import type { Trade } from "../models/trade.ts";
 import type { ReportingTrade } from "../models/reporting-trade.ts";
 import { yieldToMain, checkCancelled } from "./async-helpers.ts";
+import { getNetPl } from "./equity-curve.ts";
 
 /**
  * Key used to group trades that were opened at the same time
@@ -127,7 +128,10 @@ export function combineLegGroup(trades: Trade[]): CombinedTrade {
 
   // Aggregate numeric values
   const totalPremium = trades.reduce((sum, t) => sum + t.premium, 0);
-  const totalPL = trades.reduce((sum, t) => sum + t.pl, 0);
+  const allBasesUndeclared = trades.every((trade) => trade.plBasis === undefined);
+  const totalPL = allBasesUndeclared
+    ? trades.reduce((sum, trade) => sum + trade.pl, 0)
+    : trades.reduce((sum, trade) => sum + getNetPl(trade), 0);
   // Use the contract size of the first leg to represent the "Strategy Unit Size"
   // e.g. A 10-lot Iron Condor has 4 legs of 10 contracts.
   // We want the combined trade to say "10 contracts" (10 ICs), not 40.
@@ -241,6 +245,7 @@ export function combineLegGroup(trades: Trade[]): CombinedTrade {
 
     // Aggregated values
     pl: totalPL,
+    plBasis: allBasesUndeclared ? undefined : "net_includes_fees",
     numContracts: totalContracts,
     fundsAtClose,
     marginReq: maxMargin,

--- a/packages/lib/utils/combine-leg-groups.ts
+++ b/packages/lib/utils/combine-leg-groups.ts
@@ -8,7 +8,7 @@
  * This utility groups trades by entry timestamp and combines them into single trade records.
  */
 
-import type { Trade } from "../models/trade.ts";
+import { PlBasis, type Trade } from "../models/trade.ts";
 import type { ReportingTrade } from "../models/reporting-trade.ts";
 import { yieldToMain, checkCancelled } from "./async-helpers.ts";
 import { getNetPl } from "./equity-curve.ts";
@@ -245,7 +245,7 @@ export function combineLegGroup(trades: Trade[]): CombinedTrade {
 
     // Aggregated values
     pl: totalPL,
-    plBasis: allBasesUndeclared ? undefined : "net_includes_fees",
+    plBasis: allBasesUndeclared ? undefined : PlBasis.NetIncludesFees,
     numContracts: totalContracts,
     fundsAtClose,
     marginReq: maxMargin,

--- a/packages/lib/utils/equity-curve.ts
+++ b/packages/lib/utils/equity-curve.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-import type { Trade } from "../models/trade.ts";
+import { PlBasis, type Trade } from "../models/trade.ts";
 
 /**
  * Options for rebuilding equity curves.
@@ -115,7 +115,7 @@ export function calculateInitialCapital(
 export function getNetPl(
   trade: Pick<Trade, "pl" | "plBasis" | "openingCommissionsFees" | "closingCommissionsFees">,
 ): number {
-  if (trade.plBasis === "net_includes_fees") {
+  if (trade.plBasis === PlBasis.NetIncludesFees) {
     return trade.pl;
   }
   const openingComm = trade.openingCommissionsFees ?? 0;
@@ -129,7 +129,7 @@ export function getNetPl(
 export function getGrossPl(
   trade: Pick<Trade, "pl" | "plBasis" | "openingCommissionsFees" | "closingCommissionsFees">,
 ): number {
-  if (trade.plBasis !== "net_includes_fees") {
+  if (trade.plBasis !== PlBasis.NetIncludesFees) {
     return trade.pl;
   }
   const openingComm = trade.openingCommissionsFees ?? 0;

--- a/packages/lib/utils/equity-curve.ts
+++ b/packages/lib/utils/equity-curve.ts
@@ -36,8 +36,8 @@ export interface RebuildEquityCurveOptions {
 
   /**
    * Whether to include commissions in P&L calculation.
-   * When true, uses net P&L (pl - commissions).
-   * Default: false (uses gross P&L from trade.pl)
+   * When true, uses basis-aware net P&L and deducts fees at most once.
+   * Default: false (uses the reported value from trade.pl)
    */
   useNetPl?: boolean;
 }
@@ -86,7 +86,10 @@ export function sortTradesByCloseDate<T extends Pick<Trade, "dateClosed" | "time
  * @returns Initial capital, or undefined if cannot be determined
  */
 export function calculateInitialCapital(
-  sortedTrades: Pick<Trade, "fundsAtClose" | "pl">[],
+  sortedTrades: Pick<
+    Trade,
+    "fundsAtClose" | "pl" | "plBasis" | "openingCommissionsFees" | "closingCommissionsFees"
+  >[],
 ): number | undefined {
   if (sortedTrades.length === 0) return undefined;
 
@@ -95,21 +98,43 @@ export function calculateInitialCapital(
     return undefined;
   }
 
-  return firstTrade.fundsAtClose - firstTrade.pl;
+  const metricPl = firstTrade.plBasis === undefined ? firstTrade.pl : getNetPl(firstTrade);
+  return firstTrade.fundsAtClose - metricPl;
 }
 
 /**
- * Get the net P&L for a trade (gross P&L minus commissions).
+ * Get the net P&L for a trade, deducting commissions exactly once.
+ *
+ * Option Omega exports declare `net_includes_fees`, so their reported P/L is
+ * returned unchanged. An omitted basis preserves the historical TradeBlocks
+ * contract and is treated as `gross_before_fees`.
  *
  * @param trade - Trade to calculate net P&L for
  * @returns Net P&L value
  */
 export function getNetPl(
-  trade: Pick<Trade, "pl" | "openingCommissionsFees" | "closingCommissionsFees">,
+  trade: Pick<Trade, "pl" | "plBasis" | "openingCommissionsFees" | "closingCommissionsFees">,
 ): number {
+  if (trade.plBasis === "net_includes_fees") {
+    return trade.pl;
+  }
   const openingComm = trade.openingCommissionsFees ?? 0;
   const closingComm = trade.closingCommissionsFees ?? 0;
   return trade.pl - openingComm - closingComm;
+}
+
+/**
+ * Get gross-before-fee P/L from a basis-aware trade.
+ */
+export function getGrossPl(
+  trade: Pick<Trade, "pl" | "plBasis" | "openingCommissionsFees" | "closingCommissionsFees">,
+): number {
+  if (trade.plBasis !== "net_includes_fees") {
+    return trade.pl;
+  }
+  const openingComm = trade.openingCommissionsFees ?? 0;
+  const closingComm = trade.closingCommissionsFees ?? 0;
+  return trade.pl + openingComm + closingComm;
 }
 
 /**

--- a/packages/lib/utils/performance-export.ts
+++ b/packages/lib/utils/performance-export.ts
@@ -288,19 +288,30 @@ export const CHART_EXPORTS: ChartExportConfig[] = [
   {
     id: "rolling-metrics",
     name: "Rolling Metrics",
-    description: "30-trade rolling win rate, Sharpe, and profit factor",
+    description:
+      "30-trade rolling win rate, nonannualized trade-P/L signal-to-noise, and profit factor",
     tab: "Returns Analysis",
     exportFn: (data) => {
       const lines = ["# Rolling Metrics (30-trade window)"];
-      lines.push(toCsvRow(["Date", "Win Rate (%)", "Sharpe Ratio", "Profit Factor", "Volatility"]));
+      lines.push(
+        toCsvRow([
+          "Date",
+          "Win Rate (%)",
+          "P/L Signal-to-Noise (Nonannualized)",
+          "Profit Factor",
+          "P/L Volatility ($)",
+          "Methodology",
+        ]),
+      );
       for (const m of data.rollingMetrics) {
         lines.push(
           toCsvRow([
             m.date,
             m.winRate.toFixed(2),
-            m.sharpeRatio.toFixed(2),
+            m.plSignalToNoise.toFixed(2),
             m.profitFactor.toFixed(2),
             m.volatility.toFixed(2),
+            m.metricMethodology,
           ]),
         );
       }

--- a/packages/mcp-server/src/db/schemas.ts
+++ b/packages/mcp-server/src/db/schemas.ts
@@ -104,6 +104,8 @@ export async function ensureTradeDataTable(conn: DuckDBConnection): Promise<void
       premium DOUBLE,
       num_contracts INTEGER,
       pl DOUBLE NOT NULL,
+      reported_pl DOUBLE,
+      pl_basis VARCHAR DEFAULT 'net_includes_fees',
       date_closed DATE,
       time_closed VARCHAR,
       reason_for_close VARCHAR,
@@ -117,6 +119,18 @@ export async function ensureTradeDataTable(conn: DuckDBConnection): Promise<void
   // Backfill schema upgrades on existing databases.
   if (!(await hasColumn(conn, "trades", "trade_data", "ticker"))) {
     await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN ticker VARCHAR`);
+  }
+  if (!(await hasColumn(conn, "trades", "trade_data", "pl_basis"))) {
+    await conn.run(
+      `ALTER TABLE trades.trade_data ADD COLUMN pl_basis VARCHAR DEFAULT 'net_includes_fees'`,
+    );
+    await conn.run(
+      `UPDATE trades.trade_data SET pl_basis = 'net_includes_fees' WHERE pl_basis IS NULL`,
+    );
+  }
+  if (!(await hasColumn(conn, "trades", "trade_data", "reported_pl"))) {
+    await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN reported_pl DOUBLE`);
+    await conn.run(`UPDATE trades.trade_data SET reported_pl = pl WHERE reported_pl IS NULL`);
   }
   // Migration: add source column for trade provenance tracking.
   // 'csv' = imported from Option Omega CSV; other values may be

--- a/packages/mcp-server/src/sync/block-sync.ts
+++ b/packages/mcp-server/src/sync/block-sync.ts
@@ -91,6 +91,22 @@ function parseCSVLine(line: string): string[] {
   return result;
 }
 
+/** Parse the numeric formats accepted by the direct CSV loader. */
+function parseCsvNumber(value: string | undefined, fallback = Number.NaN): number {
+  if (!value) return fallback;
+  const parsed = Number.parseFloat(value.replace(/[$,%]/g, "").trim());
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function firstCsvValue(record: Record<string, string>, ...headers: string[]): string | undefined {
+  for (const header of headers) {
+    if (record[header] !== undefined && record[header] !== "") {
+      return record[header];
+    }
+  }
+  return undefined;
+}
+
 /**
  * Normalize CSV date strings into DuckDB-friendly YYYY-MM-DD format.
  *
@@ -177,8 +193,8 @@ async function insertTradeBatch(
   if (batch.length === 0) return;
 
   // Build VALUES placeholders: ($1, $2, $3, ...), ($15, $16, $17, ...), ...
-  // Each row has 15 columns: block_id + 13 trade fields + ticker
-  const columnsPerRow = 15;
+  // Each row has 17 columns: block_id + trade fields + reported P/L provenance + ticker.
+  const columnsPerRow = 17;
   const placeholders: string[] = [];
   const params: (string | number | null)[] = [];
 
@@ -189,13 +205,26 @@ async function insertTradeBatch(
     placeholders.push(`(${rowPlaceholders.join(", ")})`);
 
     // Parse numeric values safely
-    const premium = parseFloat(record["Premium"]);
-    const numContracts = parseInt(record["No. of Contracts"], 10);
-    const pl = parseFloat(record["P/L"]);
-    const marginReq = parseFloat(record["Margin Req."]);
-    const openingCommissions = parseFloat(record["Opening Commissions + Fees"]);
-    const closingCommissions = parseFloat(record["Closing Commissions + Fees"]);
+    const premium = parseCsvNumber(record["Premium"]);
+    const numContracts = parseCsvNumber(record["No. of Contracts"]);
+    const reportedPl = parseCsvNumber(record["P/L"]);
+    const marginReq = parseCsvNumber(record["Margin Req."]);
+    const openingCommissions = parseCsvNumber(
+      firstCsvValue(record, "Opening Commissions + Fees", "Opening comms & fees"),
+    );
+    const closingCommissions = parseCsvNumber(
+      firstCsvValue(record, "Closing Commissions + Fees", "Closing comms & fees"),
+    );
     const ticker = resolveTickerFromCsvRow(record);
+    const plBasis =
+      record["P/L Basis"] === "gross_before_fees" ? "gross_before_fees" : "net_includes_fees";
+    const safeReportedPl = isNaN(reportedPl) ? 0 : reportedPl;
+    const netPl =
+      plBasis === "gross_before_fees"
+        ? safeReportedPl -
+          (isNaN(openingCommissions) ? 0 : openingCommissions) -
+          (isNaN(closingCommissions) ? 0 : closingCommissions)
+        : safeReportedPl;
 
     // Map CSV record to column values
     params.push(
@@ -206,7 +235,9 @@ async function insertTradeBatch(
       record["Legs"] || null, // legs
       isNaN(premium) ? null : premium, // premium
       isNaN(numContracts) ? 1 : numContracts, // num_contracts
-      isNaN(pl) ? 0 : pl, // pl
+      netPl, // canonical net P/L used by analytics queries
+      safeReportedPl, // source-reported P/L
+      plBasis,
       normalizeCsvDate(record["Date Closed"]), // date_closed
       record["Time Closed"] || null, // time_closed
       record["Reason For Close"] || null, // reason_for_close
@@ -220,7 +251,7 @@ async function insertTradeBatch(
   const sql = `
     INSERT INTO trades.trade_data (
       block_id, date_opened, time_opened, strategy, legs, premium,
-      num_contracts, pl, date_closed, time_closed, reason_for_close,
+      num_contracts, pl, reported_pl, pl_basis, date_closed, time_closed, reason_for_close,
       margin_req, opening_commissions, closing_commissions, ticker
     ) VALUES ${placeholders.join(", ")}
   `;
@@ -312,8 +343,9 @@ async function insertReportingBatch(
  * Appended to content hashes so stored hashes will mismatch.
  *
  * v2: Use blockId as strategy fallback for empty Strategy columns
+ * v3: Preserve reported P/L provenance and parse formatted/aliased Option Omega fields
  */
-const PARSE_VERSION = "v2";
+const PARSE_VERSION = "v3";
 
 function versionedHash(hash: string): string {
   return `${hash}:${PARSE_VERSION}`;

--- a/packages/mcp-server/src/sync/block-sync.ts
+++ b/packages/mcp-server/src/sync/block-sync.ts
@@ -19,7 +19,7 @@ import {
 import { resolveTickerFromCsvRow } from "../utils/ticker.ts";
 import { convertToReportingTrade } from "../utils/block-loader.ts";
 import { discoverCsvFiles } from "../utils/csv-discovery.ts";
-import type { ReportingTrade } from "@tradeblocks/lib";
+import { PlBasis, type ReportingTrade } from "@tradeblocks/lib";
 
 /**
  * Result of syncing a single block
@@ -217,10 +217,20 @@ async function insertTradeBatch(
     );
     const ticker = resolveTickerFromCsvRow(record);
     const plBasis =
-      record["P/L Basis"] === "gross_before_fees" ? "gross_before_fees" : "net_includes_fees";
+      record["P/L Basis"] === PlBasis.GrossBeforeFees
+        ? PlBasis.GrossBeforeFees
+        : PlBasis.NetIncludesFees;
+    if (
+      plBasis === PlBasis.GrossBeforeFees &&
+      (!Number.isFinite(openingCommissions) || !Number.isFinite(closingCommissions))
+    ) {
+      throw new Error(
+        `Gross-before-fees P/L requires both opening and closing commission fields (CSV row ${startIdx + rowIdx + 2})`,
+      );
+    }
     const safeReportedPl = isNaN(reportedPl) ? 0 : reportedPl;
     const netPl =
-      plBasis === "gross_before_fees"
+      plBasis === PlBasis.GrossBeforeFees
         ? safeReportedPl -
           (isNaN(openingCommissions) ? 0 : openingCommissions) -
           (isNaN(closingCommissions) ? 0 : closingCommissions)
@@ -344,8 +354,9 @@ async function insertReportingBatch(
  *
  * v2: Use blockId as strategy fallback for empty Strategy columns
  * v3: Preserve reported P/L provenance and parse formatted/aliased Option Omega fields
+ * v4: Reject gross-before-fees rows whose fee fields are unavailable
  */
-const PARSE_VERSION = "v3";
+const PARSE_VERSION = "v4";
 
 function versionedHash(hash: string): string {
   return `${hash}:${PARSE_VERSION}`;

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -25,8 +25,8 @@ export {
   type CsvType,
 } from "./utils/csv-discovery.ts";
 
-// Export PortfolioStatsCalculator for testing block_diff logic
-export { PortfolioStatsCalculator } from "@tradeblocks/lib";
+// Export canonical metric helpers for integration tests.
+export { PortfolioStatsCalculator, getNetPl } from "@tradeblocks/lib";
 
 // Export correlation and tail-risk utilities for testing strategy_similarity
 export { calculateCorrelationMatrix, performTailRiskAnalysis } from "@tradeblocks/lib";
@@ -83,8 +83,17 @@ export { ensureMutableMarketTables, ensureMarketDataTables } from "./db/market-s
 export {
   filterByStrategy,
   filterByDateRange,
+  filterByRealizationDateRange,
   filterDailyLogsByDateRange,
 } from "./tools/shared/filters.ts";
+export {
+  buildModifiedTrades,
+  getScaledNetPl,
+  rebuildCounterfactualBaseline,
+  type ScaledTrade,
+} from "./tools/blocks/similarity.ts";
+export { calculatePeakExposure, rebuildSubsetEquity } from "./tools/blocks/core.ts";
+export { buildEquityCurve, buildMonthlyReturns } from "./tools/performance.ts";
 
 // Export field timing utilities for testing
 export {

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -84,6 +84,7 @@ export {
   filterByStrategy,
   filterByDateRange,
   filterByRealizationDateRange,
+  realizationDateBounds,
   filterDailyLogsByDateRange,
 } from "./tools/shared/filters.ts";
 export {

--- a/packages/mcp-server/src/tools/batch-exit-analysis.ts
+++ b/packages/mcp-server/src/tools/batch-exit-analysis.ts
@@ -404,8 +404,9 @@ export function registerBatchExitAnalysisTools(
       description:
         "Analyze how a candidate exit policy would perform across multiple trades in a block. " +
         "Replays each matching trade, evaluates exit triggers against the minute-level P&L path, " +
-        "and returns aggregate statistics (win rate, Sharpe, profit factor, drawdown) comparable " +
-        "to get_statistics. Includes per-trigger attribution showing which triggers drive outcomes. " +
+        "and returns aggregate statistics (win rate, profit factor, drawdown, and a legacy " +
+        "nonannualized trade-P&L signal-to-noise value in sharpeRatio). That legacy field is not " +
+        "comparable to the daily-return Sharpe from get_statistics. Includes per-trigger attribution. " +
         "Reads option-leg quotes via QuoteStore and underlying bars via SpotStore (cache only); " +
         "trades with missing data are skipped. Use the data-pipeline tools to backfill cache, " +
         "and strategy profiles to iterate on exit rules.",

--- a/packages/mcp-server/src/tools/blocks/analysis.ts
+++ b/packages/mcp-server/src/tools/blocks/analysis.ts
@@ -15,7 +15,11 @@ import {
 } from "../../utils/output-formatter.ts";
 import { PortfolioStatsCalculator, rebuildEquityCurve } from "@tradeblocks/lib";
 import type { Trade } from "@tradeblocks/lib";
-import { filterByStrategy, filterByDateRange } from "../shared/filters.ts";
+import {
+  filterByStrategy,
+  filterByRealizationDateRange,
+  realizationDateBounds,
+} from "../shared/filters.ts";
 import { STRESS_SCENARIOS } from "./stress-scenarios.ts";
 import { withSyncedBlock } from "../middleware/sync-middleware.ts";
 
@@ -64,16 +68,8 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
         const trades = block.trades;
 
         // Get portfolio date range for context and pre-filtering
-        const sortedTrades = [...trades].sort(
-          (a, b) => new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime(),
-        );
-        const portfolioStartDate = sortedTrades[0]?.dateOpened
-          ? new Date(sortedTrades[0].dateOpened).toISOString().split("T")[0]
-          : null;
-        const lastTrade = sortedTrades[sortedTrades.length - 1];
-        const portfolioEndDate = lastTrade?.dateClosed
-          ? new Date(lastTrade.dateClosed).toISOString().split("T")[0]
-          : null;
+        const { startDate: portfolioStartDate, endDate: portfolioEndDate } =
+          realizationDateBounds(trades);
 
         // Build list of scenarios to run
         const scenariosToRun: Array<{
@@ -176,7 +172,11 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
 
         for (const scenario of scenariosToRun) {
           // Filter trades to scenario date range
-          const scenarioTrades = filterByDateRange(trades, scenario.startDate, scenario.endDate);
+          const scenarioTrades = filterByRealizationDateRange(
+            trades,
+            scenario.startDate,
+            scenario.endDate,
+          );
 
           if (scenarioTrades.length === 0) {
             // Genuine coverage gap (had date overlap but zero trades)

--- a/packages/mcp-server/src/tools/blocks/analysis.ts
+++ b/packages/mcp-server/src/tools/blocks/analysis.ts
@@ -13,7 +13,7 @@ import {
   formatPercent,
   formatRatio,
 } from "../../utils/output-formatter.ts";
-import { PortfolioStatsCalculator } from "@tradeblocks/lib";
+import { PortfolioStatsCalculator, rebuildEquityCurve } from "@tradeblocks/lib";
 import type { Trade } from "@tradeblocks/lib";
 import { filterByStrategy, filterByDateRange } from "../shared/filters.ts";
 import { STRESS_SCENARIOS } from "./stress-scenarios.ts";
@@ -538,6 +538,16 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
 
         // Get unique strategies
         const strategies = Array.from(new Set(trades.map((t) => t.strategy))).sort();
+        const initialCapital = PortfolioStatsCalculator.calculateInitialCapital(
+          trades,
+          block.dailyLogs,
+        );
+        const rebuildArm = (armTrades: Trade[]): Trade[] =>
+          rebuildEquityCurve(armTrades, {
+            initialCapital,
+            useNetPl: true,
+          });
+        const baselineTrades = rebuildArm(trades);
 
         // Validate targetStrategy if provided
         if (targetStrategy) {
@@ -559,10 +569,7 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
 
         // Edge case: single strategy portfolio
         if (strategies.length === 1) {
-          // Use daily logs for baseline when available (consistent with get_statistics)
-          const dailyLogs =
-            block.dailyLogs && block.dailyLogs.length > 0 ? block.dailyLogs : undefined;
-          const baselineStats = calculator.calculatePortfolioStats(trades, dailyLogs);
+          const baselineStats = calculator.calculatePortfolioStats(baselineTrades, undefined, true);
 
           const summary = `Marginal Contribution: ${blockId} | Single strategy portfolio - cannot calculate marginal contribution`;
 
@@ -587,6 +594,10 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
               mostBeneficial: null,
               leastBeneficial: null,
             },
+            calculationMethodology: {
+              comparisonBasis: "realized_trade_pl_for_all_counterfactual_arms",
+              baseline: calculator.getCalculationMethodology(baselineTrades),
+            },
             message:
               "Single strategy portfolio - marginal contribution cannot be calculated (no 'without' comparison possible)",
           };
@@ -594,11 +605,9 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
           return createToolOutput(summary, structuredData);
         }
 
-        // Calculate baseline portfolio metrics using ALL trades
-        // Use daily logs for baseline when available (consistent with get_statistics)
-        const dailyLogs =
-          block.dailyLogs && block.dailyLogs.length > 0 ? block.dailyLogs : undefined;
-        const baselineStats = calculator.calculatePortfolioStats(trades, dailyLogs);
+        // A removed-strategy counterfactual cannot reuse the original
+        // full-portfolio daily log. Use the same trade-only basis for every arm.
+        const baselineStats = calculator.calculatePortfolioStats(baselineTrades, undefined, true);
 
         // Determine which strategies to analyze
         const strategiesToAnalyze = targetStrategy
@@ -606,9 +615,6 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
           : strategies;
 
         // Calculate marginal contribution for each strategy
-        // NOTE: Baseline uses daily-log Sharpe (matching get_statistics), but "without" uses
-        // trade-based Sharpe because daily logs include the removed strategy's impact.
-        // This means marginal deltas are mixed-basis, but the baseline values match get_statistics.
         type Contribution = {
           strategy: string;
           trades: number;
@@ -640,7 +646,7 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
           // Calculate "without" portfolio metrics
           // Trade-based: daily logs include the removed strategy's impact so can't be used here
           const withoutStats = calculator.calculatePortfolioStats(
-            tradesWithout,
+            rebuildArm(tradesWithout),
             undefined,
             true, // Force trade-based - daily logs include the removed strategy's impact
           );
@@ -728,6 +734,12 @@ export function registerAnalysisBlockTools(server: McpServer, baseDir: string): 
           summary: {
             mostBeneficial,
             leastBeneficial,
+          },
+          calculationMethodology: {
+            comparisonBasis: "realized_trade_pl_for_all_counterfactual_arms",
+            baseline: calculator.getCalculationMethodology(baselineTrades),
+            removedStrategyArms:
+              "Each arm uses the same close-date realized-P/L, dense-business-day, historical-DTB3 convention as baseline.",
           },
         };
 

--- a/packages/mcp-server/src/tools/blocks/core.ts
+++ b/packages/mcp-server/src/tools/blocks/core.ts
@@ -13,21 +13,38 @@ import {
   formatPercent,
   formatRatio,
 } from "../../utils/output-formatter.ts";
-import { PortfolioStatsCalculator, calculateDailyExposure } from "@tradeblocks/lib";
-import type { Trade, PeakExposure, EquityCurvePoint } from "@tradeblocks/lib";
+import {
+  PortfolioStatsCalculator,
+  calculateDailyExposure,
+  rebuildEquityCurve,
+  getNetPl,
+} from "@tradeblocks/lib";
+import type { Trade, DailyLogEntry, PeakExposure, EquityCurvePoint } from "@tradeblocks/lib";
 import { resolveTradeTicker } from "../../utils/ticker.ts";
 import {
   filterByStrategy,
-  filterByDateRange,
+  filterByRealizationDateRange,
   filterDailyLogsByDateRange,
 } from "../shared/filters.ts";
 import { withSyncedBlock, withFullSync } from "../middleware/sync-middleware.ts";
+
+export function rebuildSubsetEquity(
+  trades: Trade[],
+  allTrades: Trade[],
+  dailyLogs?: DailyLogEntry[],
+): Trade[] {
+  const initialCapital = PortfolioStatsCalculator.calculateInitialCapital(allTrades, dailyLogs);
+  return rebuildEquityCurve(trades, {
+    initialCapital,
+    useNetPl: true,
+  });
+}
 
 /**
  * Calculate peak daily exposure using the shared sweep-line algorithm.
  * Wraps the centralized calculateDailyExposure function.
  */
-function calculatePeakExposure(
+export function calculatePeakExposure(
   trades: Trade[],
   initialCapital: number,
 ): {
@@ -44,7 +61,7 @@ function calculatePeakExposure(
   let runningEquity = initialCapital;
 
   for (const trade of sortedByClose) {
-    runningEquity += trade.pl;
+    runningEquity += getNetPl(trade);
     equityCurve.push({
       date: new Date(trade.dateClosed!).toISOString(),
       equity: runningEquity,
@@ -64,8 +81,6 @@ function calculatePeakExposure(
  * Register core block tools
  */
 export function registerCoreBlockTools(server: McpServer, baseDir: string): void {
-  const calculator = new PortfolioStatsCalculator();
-
   // Tool 1: list_blocks (formerly list_backtests)
   server.registerTool(
     "list_blocks",
@@ -382,7 +397,7 @@ export function registerCoreBlockTools(server: McpServer, baseDir: string): void
     "get_statistics",
     {
       description:
-        "Get comprehensive portfolio statistics: win rate, Sharpe ratio, max drawdown, P&L metrics, and more. Use blockId from list_blocks. Optionally filter by strategy, ticker, or date range.",
+        "Get comprehensive portfolio statistics with explicit P/L and Sharpe methodology. Option Omega P/L is already net of fees. Sharpe defaults to historical FRED DTB3 rates; optionally provide a fixed annual rate. Use blockId from list_blocks. Optionally filter by strategy, ticker, or date range.",
       inputSchema: z.object({
         blockId: z.string().describe("Block ID from list_blocks (e.g., 'main-port')"),
         strategy: z.string().optional().describe("Filter by strategy name (case-insensitive)"),
@@ -392,19 +407,31 @@ export function registerCoreBlockTools(server: McpServer, baseDir: string): void
           .describe("Filter trades by underlying ticker symbol (e.g., 'SPY', 'AAPL')"),
         startDate: z.string().optional().describe("Start date filter (YYYY-MM-DD)"),
         endDate: z.string().optional().describe("End date filter (YYYY-MM-DD)"),
+        riskFreeRateAnnualPct: z
+          .number()
+          .gt(-100)
+          .lte(100)
+          .optional()
+          .describe(
+            "Optional fixed annual risk-free rate in percentage points (for example, 2 means 2%). Omit to use historical FRED DTB3 rates.",
+          ),
       }),
     },
     withSyncedBlock(
       baseDir,
-      async ({ blockId, strategy, tickerFilter, startDate, endDate }, { syncResult }) => {
+      async (
+        { blockId, strategy, tickerFilter, startDate, endDate, riskFreeRateAnnualPct },
+        { syncResult },
+      ) => {
         try {
           const block = await loadBlock(baseDir, blockId);
-          let trades = block.trades;
+          const allTrades = block.trades;
+          let trades = allTrades;
           const dailyLogs = block.dailyLogs;
 
           // Apply filters
           trades = filterByStrategy(trades, strategy);
-          trades = filterByDateRange(trades, startDate, endDate);
+          trades = filterByRealizationDateRange(trades, startDate, endDate);
 
           // Apply ticker filter (supports both explicit ticker columns and legs-derived symbols)
           if (tickerFilter) {
@@ -425,18 +452,27 @@ export function registerCoreBlockTools(server: McpServer, baseDir: string): void
 
           // Filter daily logs by date range when date filters are provided
           // Only applies when not strategy-filtered (daily logs represent full portfolio)
-          const isStrategyFiltered = !!strategy;
+          const isSubsetFiltered = !!strategy || !!tickerFilter;
+          if (isSubsetFiltered) {
+            trades = rebuildSubsetEquity(trades, allTrades, dailyLogs);
+          }
           let filteredDailyLogs = dailyLogs;
-          if (!isStrategyFiltered && (startDate || endDate) && dailyLogs) {
+          if (!isSubsetFiltered && (startDate || endDate) && dailyLogs) {
             filteredDailyLogs = filterDailyLogsByDateRange(dailyLogs, startDate, endDate);
           }
 
-          // When strategy filter is applied, we MUST use trade-based calculations
-          // because daily logs represent the FULL portfolio, not per-strategy
-          const stats = calculator.calculatePortfolioStats(
+          // When a subset filter is applied, daily logs cannot be used because they
+          // represent the full portfolio rather than the selected strategy/ticker.
+          const effectiveDailyLogs = isSubsetFiltered ? undefined : filteredDailyLogs;
+          const requestCalculator = new PortfolioStatsCalculator({ riskFreeRateAnnualPct });
+          const stats = requestCalculator.calculatePortfolioStats(
             trades,
-            isStrategyFiltered ? undefined : filteredDailyLogs,
-            isStrategyFiltered,
+            effectiveDailyLogs,
+            isSubsetFiltered,
+          );
+          const calculationMethodology = requestCalculator.getCalculationMethodology(
+            trades,
+            effectiveDailyLogs,
           );
 
           // Calculate peak daily exposure
@@ -453,6 +489,7 @@ export function registerCoreBlockTools(server: McpServer, baseDir: string): void
               tickerFilter: tickerFilter ?? null,
               startDate: startDate ?? null,
               endDate: endDate ?? null,
+              riskFreeRateAnnualPct: riskFreeRateAnnualPct ?? null,
             },
             stats: {
               totalTrades: stats.totalTrades,
@@ -487,6 +524,7 @@ export function registerCoreBlockTools(server: McpServer, baseDir: string): void
               byDollars: peakExposure.peakByDollars,
               byPercent: peakExposure.peakByPercent,
             },
+            calculationMethodology,
             // Add sync info if sync occurred
             ...(syncResult.status === "synced"
               ? { syncInfo: { status: "synced", tradeCount: syncResult.tradeCount } }

--- a/packages/mcp-server/src/tools/blocks/similarity.ts
+++ b/packages/mcp-server/src/tools/blocks/similarity.ts
@@ -12,9 +12,11 @@ import {
   PortfolioStatsCalculator,
   calculateCorrelationMatrix,
   performTailRiskAnalysis,
+  getNetPl,
+  rebuildEquityCurve,
 } from "@tradeblocks/lib";
 import type { Trade } from "@tradeblocks/lib";
-import { filterByDateRange, filterDailyLogsByDateRange } from "../shared/filters.ts";
+import { filterByRealizationDateRange } from "../shared/filters.ts";
 import { withSyncedBlock } from "../middleware/sync-middleware.ts";
 import { getConnection } from "../../db/connection.ts";
 import { getProfile } from "../../db/profile-schemas.ts";
@@ -27,6 +29,71 @@ const SIMILARITY_DEFAULTS = {
   minSharedDays: 30,
   topN: 5,
 };
+
+export type ScaledTrade = Trade & {
+  scaledPl: number;
+  scaledOpeningComm: number;
+  scaledClosingComm: number;
+  weight: number;
+};
+
+export function getScaledNetPl(trade: ScaledTrade): number {
+  return getNetPl({
+    ...trade,
+    pl: trade.scaledPl,
+    openingCommissionsFees: trade.scaledOpeningComm,
+    closingCommissionsFees: trade.scaledClosingComm,
+  });
+}
+
+export function rebuildCounterfactualBaseline(trades: Trade[]): Trade[] {
+  return rebuildEquityCurve(trades, {
+    initialCapital: PortfolioStatsCalculator.calculateInitialCapital(trades),
+    useNetPl: true,
+  });
+}
+
+/** Rebuild a scaled equity curve using net P/L in the trade's declared basis. */
+export function buildModifiedTrades(scaledTrades: ScaledTrade[], originalTrades: Trade[]): Trade[] {
+  const sortedOriginal = [...originalTrades]
+    .filter((trade) => trade.dateClosed && trade.fundsAtClose !== undefined)
+    .sort((a, b) => {
+      const dateA = new Date(a.dateClosed!);
+      const dateB = new Date(b.dateClosed!);
+      const cmp = dateA.getTime() - dateB.getTime();
+      if (cmp !== 0) return cmp;
+      return (a.timeClosed || "").localeCompare(b.timeClosed || "");
+    });
+  const originalInitialCapital =
+    sortedOriginal.length > 0
+      ? PortfolioStatsCalculator.calculateInitialCapital(sortedOriginal)
+      : 1000000;
+
+  const sortedScaled = [...scaledTrades]
+    .filter((trade) => trade.dateClosed)
+    .sort((a, b) => {
+      const dateA = new Date(a.dateClosed!);
+      const dateB = new Date(b.dateClosed!);
+      const cmp = dateA.getTime() - dateB.getTime();
+      if (cmp !== 0) return cmp;
+      return (a.timeClosed || "").localeCompare(b.timeClosed || "");
+    });
+
+  let runningEquity = originalInitialCapital;
+  const scaledFundsMap = new Map<ScaledTrade, number>();
+  for (const trade of sortedScaled) {
+    runningEquity += getScaledNetPl(trade);
+    scaledFundsMap.set(trade, runningEquity);
+  }
+
+  return scaledTrades.map((trade) => ({
+    ...trade,
+    pl: trade.scaledPl,
+    openingCommissionsFees: trade.scaledOpeningComm,
+    closingCommissionsFees: trade.scaledClosingComm,
+    fundsAtClose: scaledFundsMap.get(trade) ?? trade.fundsAtClose,
+  }));
+}
 
 /**
  * Register similarity block tools
@@ -412,14 +479,6 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
             return [];
           }
 
-          // Shared type for scaled trades
-          type ScaledTrade = Trade & {
-            scaledPl: number;
-            scaledOpeningComm: number;
-            scaledClosingComm: number;
-            weight: number;
-          };
-
           // Helper: build scaled trades with optional maxContractsPerTrade ceilings
           function buildScaledTrades(
             tradesToScale: Trade[],
@@ -455,52 +514,6 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               } as ScaledTrade);
             }
             return { scaledTrades: scaled, cappedStrategies };
-          }
-
-          // Helper: build modified Trade[] with recalculated fundsAtClose for portfolio stats
-          function buildModifiedTrades(
-            scaledTrades: ScaledTrade[],
-            originalTrades: Trade[],
-          ): Trade[] {
-            const sortedOriginal = [...originalTrades]
-              .filter((t) => t.dateClosed && t.fundsAtClose !== undefined)
-              .sort((a, b) => {
-                const dateA = new Date(a.dateClosed!);
-                const dateB = new Date(b.dateClosed!);
-                const cmp = dateA.getTime() - dateB.getTime();
-                if (cmp !== 0) return cmp;
-                return (a.timeClosed || "").localeCompare(b.timeClosed || "");
-              });
-            const originalInitialCapital =
-              sortedOriginal.length > 0
-                ? PortfolioStatsCalculator.calculateInitialCapital(sortedOriginal)
-                : 1000000;
-
-            const sortedScaled = [...scaledTrades]
-              .filter((t) => t.dateClosed)
-              .sort((a, b) => {
-                const dateA = new Date(a.dateClosed!);
-                const dateB = new Date(b.dateClosed!);
-                const cmp = dateA.getTime() - dateB.getTime();
-                if (cmp !== 0) return cmp;
-                return (a.timeClosed || "").localeCompare(b.timeClosed || "");
-              });
-
-            let runningEquity = originalInitialCapital;
-            const scaledFundsMap = new Map<number, number>();
-            for (const st of sortedScaled) {
-              runningEquity += st.scaledPl;
-              const idx = scaledTrades.indexOf(st);
-              scaledFundsMap.set(idx, runningEquity);
-            }
-
-            return scaledTrades.map((st, idx) => ({
-              ...st,
-              pl: st.scaledPl,
-              openingCommissionsFees: st.scaledOpeningComm,
-              closingCommissionsFees: st.scaledClosingComm,
-              fundsAtClose: scaledFundsMap.get(idx) ?? st.fundsAtClose,
-            }));
           }
 
           // Helper: calculate comparison deltas
@@ -580,7 +593,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               try {
                 const entryBlock = await loadBlock(baseDir, tradeSourceBlockId);
                 entryTrades = filterTradesByStrategy(entryBlock.trades, entry.strategyName);
-                entryTrades = filterByDateRange(entryTrades, startDate, endDate);
+                entryTrades = filterByRealizationDateRange(entryTrades, startDate, endDate);
               } catch {
                 // Block load failed - skip this strategy
                 perStrategyBreakdown.push({
@@ -635,11 +648,11 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               // Calculate strategy P&L
               let origNetPl = 0;
               for (const t of entryTrades) {
-                origNetPl += t.pl - t.openingCommissionsFees - t.closingCommissionsFees;
+                origNetPl += getNetPl(t);
               }
               let scaledNetPl = 0;
               for (const st of entryScaled) {
-                scaledNetPl += st.scaledPl - st.scaledOpeningComm - st.scaledClosingComm;
+                scaledNetPl += getScaledNetPl(st);
               }
 
               const breakdown: MultiStrategyBreakdown = {
@@ -683,6 +696,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               undefined,
               true,
             );
+            const combinedMethodology = calculator.getCalculationMethodology(modifiedTrades);
 
             // Build uncapped comparison if requested and any strategy was capped
             let uncappedComparison: Record<string, unknown> | undefined;
@@ -699,7 +713,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
                 try {
                   const entryBlock = await loadBlock(baseDir, tradeSourceBlockId);
                   let entryTrades = filterTradesByStrategy(entryBlock.trades, entry.strategyName);
-                  entryTrades = filterByDateRange(entryTrades, startDate, endDate);
+                  entryTrades = filterByRealizationDateRange(entryTrades, startDate, endDate);
                   const wm: Record<string, number> = {};
                   for (const name of new Set(entryTrades.map((t) => t.strategy))) {
                     wm[name] = entry.scaleFactor;
@@ -740,6 +754,10 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
                 netPl: combinedStats.netPl,
                 totalTrades: combinedStats.totalTrades,
               },
+              calculationMethodology: {
+                comparisonBasis: "realized_trade_pl_for_all_counterfactual_arms",
+                combined: combinedMethodology,
+              },
               perStrategy: perStrategyBreakdown,
               dataAvailability,
             };
@@ -758,7 +776,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
           let trades = block.trades;
 
           // Apply date range filter
-          trades = filterByDateRange(trades, startDate, endDate);
+          trades = filterByRealizationDateRange(trades, startDate, endDate);
 
           if (trades.length === 0) {
             return {
@@ -834,7 +852,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
                 try {
                   const backtestBlock = await loadBlock(baseDir, lookup.profile.blockId);
                   let backtestTrades = filterTradesByStrategy(backtestBlock.trades, strategy);
-                  backtestTrades = filterByDateRange(backtestTrades, startDate, endDate);
+                  backtestTrades = filterByRealizationDateRange(backtestTrades, startDate, endDate);
 
                   if (backtestTrades.length > 0) {
                     tradesToUse = tradesToUse.filter(
@@ -860,15 +878,10 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
             }
           }
 
-          // Calculate baseline portfolio metrics (from original trades, before substitution)
-          const dailyLogs =
-            block.dailyLogs && block.dailyLogs.length > 0
-              ? filterDailyLogsByDateRange(block.dailyLogs, startDate, endDate)
-              : undefined;
-          const baselineStats = calculator.calculatePortfolioStats(
-            trades,
-            dailyLogs && dailyLogs.length > 0 ? dailyLogs : undefined,
-          );
+          // Counterfactual arms cannot reuse a full-portfolio daily log after
+          // strategy weights change, so every arm uses the same trade-only basis.
+          const baselineTrades = rebuildCounterfactualBaseline(trades);
+          const baselineStats = calculator.calculatePortfolioStats(baselineTrades, undefined, true);
 
           // Build scaled trades with optional ceilings
           const hasCeilings = Object.keys(maxContractsCeilings).length > 0;
@@ -880,6 +893,8 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
 
           const modifiedTrades = buildModifiedTrades(scaledTrades, trades);
           const scaledStats = calculator.calculatePortfolioStats(modifiedTrades, undefined, true);
+          const baselineMethodology = calculator.getCalculationMethodology(baselineTrades);
+          const scaledMethodology = calculator.getCalculationMethodology(modifiedTrades);
 
           // Uncapped comparison if requested and any strategy was capped
           let uncappedComparison: Record<string, unknown> | undefined;
@@ -964,7 +979,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               originalByStrategy[trade.strategy] = { trades: 0, netPl: 0 };
             }
             originalByStrategy[trade.strategy].trades++;
-            const netPl = trade.pl - trade.openingCommissionsFees - trade.closingCommissionsFees;
+            const netPl = getNetPl(trade);
             originalByStrategy[trade.strategy].netPl += netPl;
             totalOriginalPl += netPl;
           }
@@ -975,7 +990,7 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
               scaledByStrategy[st.strategy] = { trades: 0, netPl: 0 };
             }
             scaledByStrategy[st.strategy].trades++;
-            const netPl = st.scaledPl - st.scaledOpeningComm - st.scaledClosingComm;
+            const netPl = getScaledNetPl(st);
             scaledByStrategy[st.strategy].netPl += netPl;
             totalScaledPl += netPl;
           }
@@ -1056,6 +1071,11 @@ export function registerSimilarityBlockTools(server: McpServer, baseDir: string)
             unknownStrategies: unknownStrategies.length > 0 ? unknownStrategies : undefined,
             comparison,
             perStrategy,
+            calculationMethodology: {
+              comparisonBasis: "realized_trade_pl_for_all_counterfactual_arms",
+              baseline: baselineMethodology,
+              scaled: scaledMethodology,
+            },
           };
 
           // Add profile-aware metadata only when profiles were found

--- a/packages/mcp-server/src/tools/imports.ts
+++ b/packages/mcp-server/src/tools/imports.ts
@@ -10,6 +10,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { PlBasis } from "@tradeblocks/lib";
 import { importCsv } from "../utils/block-loader.ts";
 import { createToolOutput } from "../utils/output-formatter.ts";
 
@@ -73,8 +74,8 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
               "'dailylog' for daily portfolio values, 'reportinglog' for actual/reported trades",
           ),
         plBasis: z
-          .enum(["net_includes_fees", "gross_before_fees"])
-          .default("net_includes_fees")
+          .nativeEnum(PlBasis)
+          .default(PlBasis.NetIncludesFees)
           .describe(
             "Basis of the tradelog P/L column. Use 'net_includes_fees' for Option Omega exports (default), or 'gross_before_fees' when commission/fee columns still need to be deducted.",
           ),

--- a/packages/mcp-server/src/tools/imports.ts
+++ b/packages/mcp-server/src/tools/imports.ts
@@ -72,6 +72,12 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
             "Type of CSV: 'tradelog' (default) for trade records with P/L, " +
               "'dailylog' for daily portfolio values, 'reportinglog' for actual/reported trades",
           ),
+        plBasis: z
+          .enum(["net_includes_fees", "gross_before_fees"])
+          .default("net_includes_fees")
+          .describe(
+            "Basis of the tradelog P/L column. Use 'net_includes_fees' for Option Omega exports (default), or 'gross_before_fees' when commission/fee columns still need to be deducted.",
+          ),
         searchPaths: z
           .array(z.string())
           .optional()
@@ -81,7 +87,7 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
           ),
       }),
     },
-    async ({ csvPath, blockName, csvType, searchPaths }) => {
+    async ({ csvPath, blockName, csvType, plBasis, searchPaths }) => {
       try {
         let resolvedPath = csvPath;
 
@@ -122,6 +128,7 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
           csvPath: resolvedPath,
           blockName,
           csvType,
+          plBasis,
         });
 
         // Brief summary for user display (use result.csvType which reflects auto-detection)
@@ -132,6 +139,7 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
           blockId: result.blockId,
           name: result.name,
           csvType: result.csvType,
+          plBasis: result.plBasis ?? null,
           sourcePath: resolvedPath,
           recordCount: result.recordCount,
           dateRange: result.dateRange,

--- a/packages/mcp-server/src/tools/performance.ts
+++ b/packages/mcp-server/src/tools/performance.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { loadBlock, loadReportingLog } from "../utils/block-loader.ts";
 import { createToolOutput, formatPercent, formatCurrency } from "../utils/output-formatter.ts";
+import { filterByRealizationDateRange } from "./shared/filters.ts";
 import type { Trade, ReportingTrade } from "@tradeblocks/lib";
 import {
   normalizeToOneLot,
@@ -17,7 +18,14 @@ import {
   calculateScaledPl,
   applyStrategyFilter,
   applyDateRangeFilter,
+  getNetPl,
+  getGrossPl,
+  PortfolioStatsCalculator,
 } from "@tradeblocks/lib";
+
+function getRealizationDate(trade: Trade): Date {
+  return new Date(trade.dateClosed ?? trade.dateOpened);
+}
 
 /**
  * MFE/MAE data point for a single trade's excursion metrics
@@ -117,8 +125,8 @@ function calculateTradeExcursionMetrics(trade: Trade, tradeNumber: number): MFEM
     strategy: trade.strategy || "Unknown",
     mfe: totalMFE || 0,
     mae: totalMAE || 0,
-    pl: trade.pl,
-    isWinner: trade.pl > 0,
+    pl: getNetPl(trade),
+    isWinner: getNetPl(trade) > 0,
     basis,
   };
 
@@ -134,7 +142,7 @@ function calculateTradeExcursionMetrics(trade: Trade, tradeNumber: number): MFEM
 
   // Profit capture: what % of max profit was actually captured
   if (totalMFE && totalMFE > 0) {
-    dataPoint.profitCapturePercent = (trade.pl / totalMFE) * 100;
+    dataPoint.profitCapturePercent = (getNetPl(trade) / totalMFE) * 100;
   }
 
   // Excursion ratio: reward/risk
@@ -225,7 +233,7 @@ function getISOWeekNumber(date: Date): number {
 /**
  * Calculate equity curve from trades
  */
-function buildEquityCurve(trades: Trade[]): Array<{
+export function buildEquityCurve(trades: Trade[]): Array<{
   date: string;
   equity: number;
   highWaterMark: number;
@@ -236,12 +244,11 @@ function buildEquityCurve(trades: Trade[]): Array<{
   }
 
   const sortedTrades = [...trades].sort(
-    (a, b) => new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime(),
+    (a, b) => getRealizationDate(a).getTime() - getRealizationDate(b).getTime(),
   );
 
   // Calculate initial capital from first trade
-  const firstTrade = sortedTrades[0];
-  let initialCapital = firstTrade.fundsAtClose - firstTrade.pl;
+  let initialCapital = PortfolioStatsCalculator.calculateInitialCapital(sortedTrades);
   if (!isFinite(initialCapital) || initialCapital <= 0) {
     initialCapital = 100000;
   }
@@ -256,7 +263,7 @@ function buildEquityCurve(trades: Trade[]): Array<{
     tradeNumber: number;
   }> = [
     {
-      date: formatDateKey(new Date(sortedTrades[0].dateOpened)),
+      date: formatDateKey(getRealizationDate(sortedTrades[0])),
       equity: runningEquity,
       highWaterMark,
       tradeNumber: 0,
@@ -264,11 +271,11 @@ function buildEquityCurve(trades: Trade[]): Array<{
   ];
 
   sortedTrades.forEach((trade, index) => {
-    runningEquity += trade.pl;
+    runningEquity += getNetPl(trade);
     highWaterMark = Math.max(highWaterMark, runningEquity);
 
     curve.push({
-      date: formatDateKey(new Date(trade.dateOpened)),
+      date: formatDateKey(getRealizationDate(trade)),
       equity: runningEquity,
       highWaterMark,
       tradeNumber: index + 1,
@@ -296,22 +303,22 @@ function buildDrawdownSeries(
 /**
  * Calculate monthly returns matrix
  */
-function buildMonthlyReturns(trades: Trade[]): Record<number, Record<number, number>> {
+export function buildMonthlyReturns(trades: Trade[]): Record<number, Record<number, number>> {
   const monthlyData: Record<string, number> = {};
 
   trades.forEach((trade) => {
-    const date = new Date(trade.dateOpened);
+    const date = getRealizationDate(trade);
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const monthKey = `${year}-${String(month).padStart(2, "0")}`;
-    monthlyData[monthKey] = (monthlyData[monthKey] || 0) + trade.pl;
+    monthlyData[monthKey] = (monthlyData[monthKey] || 0) + getNetPl(trade);
   });
 
   const monthlyReturns: Record<number, Record<number, number>> = {};
   const years = new Set<number>();
 
   trades.forEach((trade) => {
-    years.add(new Date(trade.dateOpened).getFullYear());
+    years.add(getRealizationDate(trade).getFullYear());
   });
 
   Array.from(years)
@@ -336,7 +343,7 @@ function buildReturnDistribution(
 ): Array<{ rangeStart: number; rangeEnd: number; count: number }> {
   if (trades.length === 0) return [];
 
-  const returns = trades.map((t) => t.pl);
+  const returns = trades.map(getNetPl);
   const minReturn = Math.min(...returns);
   const maxReturn = Math.max(...returns);
   const range = maxReturn - minReturn || 1;
@@ -376,7 +383,7 @@ function buildDayOfWeekData(trades: Trade[]): Array<{
   > = {};
 
   trades.forEach((trade) => {
-    const date = new Date(trade.dateOpened);
+    const date = getRealizationDate(trade);
     const jsDay = date.getDay();
     const pythonWeekday = jsDay === 0 ? 6 : jsDay - 1;
     const day = dayNames[pythonWeekday];
@@ -385,11 +392,11 @@ function buildDayOfWeekData(trades: Trade[]): Array<{
       dayData[day] = { count: 0, totalPl: 0, totalPlPercent: 0, percentCount: 0 };
     }
     dayData[day].count++;
-    dayData[day].totalPl += trade.pl;
+    dayData[day].totalPl += getNetPl(trade);
 
     // Calculate ROM if margin available
     if (trade.marginReq && trade.marginReq > 0) {
-      dayData[day].totalPlPercent += (trade.pl / trade.marginReq) * 100;
+      dayData[day].totalPlPercent += (getNetPl(trade) / trade.marginReq) * 100;
       dayData[day].percentCount++;
     }
   });
@@ -426,7 +433,7 @@ function buildStreakData(trades: Trade[]): {
   } | null;
 } {
   const sortedTrades = [...trades].sort(
-    (a, b) => new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime(),
+    (a, b) => getRealizationDate(a).getTime() - getRealizationDate(b).getTime(),
   );
 
   const winStreaks: number[] = [];
@@ -435,7 +442,7 @@ function buildStreakData(trades: Trade[]): {
   let isWinStreak = false;
 
   sortedTrades.forEach((trade) => {
-    const isWin = trade.pl > 0;
+    const isWin = getNetPl(trade) > 0;
 
     if (currentStreak === 0) {
       currentStreak = 1;
@@ -503,7 +510,7 @@ function calculateRunsTest(trades: Trade[]): {
 } | null {
   if (trades.length < 20) return null;
 
-  const outcomes = trades.map((t) => (t.pl > 0 ? 1 : 0));
+  const outcomes = trades.map((t) => (getNetPl(t) > 0 ? 1 : 0));
   const n1 = outcomes.filter((o) => o === 1).length;
   const n0 = outcomes.filter((o) => o === 0).length;
 
@@ -584,9 +591,9 @@ function buildTradeSequence(trades: Trade[]): Array<{
       typeof trade.marginReq === "number" && isFinite(trade.marginReq) ? trade.marginReq : null;
     return {
       tradeNumber: index + 1,
-      pl: trade.pl,
-      rom: marginReq && marginReq > 0 ? (trade.pl / marginReq) * 100 : null,
-      date: formatDateKey(new Date(trade.dateOpened)),
+      pl: getNetPl(trade),
+      rom: marginReq && marginReq > 0 ? (getNetPl(trade) / marginReq) * 100 : null,
+      date: formatDateKey(getRealizationDate(trade)),
       marginReq,
       strategy: trade.strategy || "Unknown",
     };
@@ -603,8 +610,8 @@ function buildRomTimeline(
     .map((trade, index) => {
       if (!trade.marginReq || trade.marginReq <= 0) return null;
       return {
-        date: formatDateKey(new Date(trade.dateOpened)),
-        rom: (trade.pl / trade.marginReq) * 100,
+        date: formatDateKey(getRealizationDate(trade)),
+        rom: (getNetPl(trade) / trade.marginReq) * 100,
         tradeNumber: index + 1,
       };
     })
@@ -612,9 +619,10 @@ function buildRomTimeline(
 }
 
 /**
- * Build rolling metrics (30-trade rolling window)
- * Note: Uses fixed 2.0% risk-free rate for Sharpe as a simplification for visualization.
- * The accurate date-based Sharpe is computed by portfolio-stats.ts for actual statistics.
+ * Build rolling metrics (30-trade rolling window).
+ *
+ * `sharpeRatio` is retained for response compatibility but is a nonannualized
+ * trade-P/L signal-to-noise visualization, not portfolio daily-return Sharpe.
  */
 function buildRollingMetrics(
   trades: Trade[],
@@ -640,7 +648,7 @@ function buildRollingMetrics(
     avgPl: number;
   }> = [];
 
-  const plValues = trades.map((t) => t.pl);
+  const plValues = trades.map(getNetPl);
 
   // Initialize window state
   let windowSum = 0;
@@ -679,14 +687,10 @@ function buildRollingMetrics(
           ? 999
           : 0;
 
-    // Sharpe uses fixed 2.0% risk-free rate approximation for visualization
-    // The accurate date-based rate is used in portfolio-stats.ts calculations
-    const dailyRfr = 2.0 / 100 / 252;
-    const excessReturn = avgReturn - dailyRfr;
-    const sharpeRatio = volatility > 0 ? excessReturn / volatility : 0;
+    const sharpeRatio = volatility > 0 ? avgReturn / volatility : 0;
 
     metrics.push({
-      date: formatDateKey(new Date(trades[i].dateOpened)),
+      date: formatDateKey(getRealizationDate(trades[i])),
       tradeNumber: i + 1,
       winRate,
       sharpeRatio,
@@ -746,10 +750,10 @@ function buildExitReasonBreakdown(trades: Trade[]): Array<{
       romCount: 0,
     };
     current.count += 1;
-    current.totalPl += trade.pl;
+    current.totalPl += getNetPl(trade);
 
     if (trade.marginReq && trade.marginReq > 0) {
-      current.totalRom += (trade.pl / trade.marginReq) * 100;
+      current.totalRom += (getNetPl(trade) / trade.marginReq) * 100;
       current.romCount++;
     }
 
@@ -794,7 +798,7 @@ function buildHoldingPeriods(trades: Trade[]): Array<{
       dateClosed: closeDate ? formatDateKey(closeDate) : null,
       durationHours,
       durationDays: durationHours / 24,
-      pl: trade.pl,
+      pl: getNetPl(trade),
       strategy: trade.strategy || "Unknown",
     };
   });
@@ -816,13 +820,13 @@ function buildPremiumEfficiency(trades: Trade[]): Array<{
       typeof trade.premium === "number" && isFinite(trade.premium) ? trade.premium : null;
     let efficiencyPct: number | null = null;
     if (premium !== null && premium !== 0) {
-      efficiencyPct = (trade.pl / Math.abs(premium)) * 100;
+      efficiencyPct = (getNetPl(trade) / Math.abs(premium)) * 100;
     }
 
     return {
       tradeNumber: index + 1,
-      date: formatDateKey(new Date(trade.dateOpened)),
-      pl: trade.pl,
+      date: formatDateKey(getRealizationDate(trade)),
+      pl: getNetPl(trade),
       premium,
       efficiencyPct,
       strategy: trade.strategy || "Unknown",
@@ -898,7 +902,7 @@ function buildMarginUtilization(
         fundsAtClose,
         utilizationPct: fundsAtClose > 0 ? (marginReq / fundsAtClose) * 100 : null,
         numContracts,
-        pl: trade.pl,
+        pl: getNetPl(trade),
       };
     })
     .filter((item): item is NonNullable<typeof item> => item !== null);
@@ -933,8 +937,9 @@ function buildVolatilityRegimes(trades: Trade[]): Array<{
         date: formatDateKey(new Date(trade.dateOpened)),
         openingVix,
         closingVix,
-        pl: trade.pl,
-        rom: trade.marginReq && trade.marginReq > 0 ? (trade.pl / trade.marginReq) * 100 : null,
+        pl: getNetPl(trade),
+        rom:
+          trade.marginReq && trade.marginReq > 0 ? (getNetPl(trade) / trade.marginReq) * 100 : null,
       };
     })
     .filter((item): item is NonNullable<typeof item> => item !== null);
@@ -949,12 +954,11 @@ function buildMonthlyReturnsPercent(trades: Trade[]): Record<number, Record<numb
 
   // Sort trades by date
   const sortedTrades = [...trades].sort(
-    (a, b) => new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime(),
+    (a, b) => getRealizationDate(a).getTime() - getRealizationDate(b).getTime(),
   );
 
   // Calculate initial capital from first trade
-  const firstTrade = sortedTrades[0];
-  let runningCapital = firstTrade.fundsAtClose - firstTrade.pl;
+  let runningCapital = PortfolioStatsCalculator.calculateInitialCapital(sortedTrades);
   if (!isFinite(runningCapital) || runningCapital <= 0) {
     runningCapital = 100000;
   }
@@ -964,7 +968,7 @@ function buildMonthlyReturnsPercent(trades: Trade[]): Record<number, Record<numb
   const years = new Set<number>();
 
   sortedTrades.forEach((trade) => {
-    const date = new Date(trade.dateOpened);
+    const date = getRealizationDate(trade);
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const monthKey = `${year}-${String(month).padStart(2, "0")}`;
@@ -978,7 +982,7 @@ function buildMonthlyReturnsPercent(trades: Trade[]): Record<number, Record<numb
       };
     }
 
-    monthlyData[monthKey].pl += trade.pl;
+    monthlyData[monthKey].pl += getNetPl(trade);
   });
 
   // Calculate percentage returns
@@ -1029,20 +1033,6 @@ function buildMonthlyReturnsPercent(trades: Trade[]): Record<number, Record<numb
     });
 
   return monthlyReturnsPercent;
-}
-
-/**
- * Apply date range filter to trades
- */
-function filterByDateRange(trades: Trade[], fromDate?: string, toDate?: string): Trade[] {
-  if (!fromDate && !toDate) return trades;
-
-  return trades.filter((trade) => {
-    const tradeDate = formatDateKey(new Date(trade.dateOpened));
-    if (fromDate && tradeDate < fromDate) return false;
-    if (toDate && tradeDate > toDate) return false;
-    return true;
-  });
 }
 
 // Note: normalizeTradesToOneLot was removed and replaced with shared utility
@@ -1205,7 +1195,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
 
         // Apply date range filter
         if (dateRange) {
-          trades = filterByDateRange(trades, dateRange.from, dateRange.to);
+          trades = filterByRealizationDateRange(trades, dateRange.from, dateRange.to);
         }
 
         // Apply normalization if requested
@@ -1324,6 +1314,11 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
 
         if (charts.includes("rolling_metrics")) {
           chartData.rollingMetrics = buildRollingMetrics(trades, rollingWindowSize);
+          chartData.rollingMetricsMethodology = {
+            sharpeRatio:
+              "Legacy nonannualized mean trade P/L divided by population standard deviation; not comparable to get_statistics daily-return Sharpe.",
+            window: `${rollingWindowSize} trades`,
+          };
           dataPoints += (chartData.rollingMetrics as unknown[]).length;
         }
 
@@ -1541,7 +1536,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
     "get_period_returns",
     {
       description:
-        "Get P&L breakdown by period (monthly, weekly, or daily) with gross P/L, commissions, and net P/L",
+        "Get P&L breakdown by period (monthly, weekly, or daily) with reported P/L, commissions, and basis-aware net P/L. Option Omega reported P/L already includes fees.",
       inputSchema: z.object({
         blockId: z.string().describe("Block folder name"),
         strategy: z.string().optional().describe("Filter by strategy name (case-insensitive)"),
@@ -1575,10 +1570,12 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
         trades = filterByStrategy(trades, strategy);
 
         // Apply date range filter (takes precedence over year)
+        const realizedDate = (trade: Trade): Date => new Date(trade.dateClosed ?? trade.dateOpened);
+
         if (dateRange) {
-          trades = filterByDateRange(trades, dateRange.from, dateRange.to);
+          trades = filterByRealizationDateRange(trades, dateRange.from, dateRange.to);
         } else if (year !== undefined) {
-          trades = trades.filter((t) => new Date(t.dateOpened).getFullYear() === year);
+          trades = trades.filter((trade) => realizedDate(trade).getFullYear() === year);
         }
 
         // Apply normalization if requested
@@ -1606,6 +1603,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
         const periodData: Map<
           string,
           {
+            reportedPl: number;
             grossPl: number;
             commissions: number;
             netPl: number;
@@ -1614,7 +1612,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
         > = new Map();
 
         trades.forEach((trade) => {
-          const date = new Date(trade.dateOpened);
+          const date = realizedDate(trade);
           let periodKey: string;
 
           if (period === "monthly") {
@@ -1631,6 +1629,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
           }
 
           const existing = periodData.get(periodKey) || {
+            reportedPl: 0,
             grossPl: 0,
             commissions: 0,
             netPl: 0,
@@ -1640,9 +1639,10 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
           const totalCommissions =
             (trade.openingCommissionsFees ?? 0) + (trade.closingCommissionsFees ?? 0);
 
-          existing.grossPl += trade.pl;
+          existing.reportedPl += trade.pl;
+          existing.grossPl += getGrossPl(trade);
           existing.commissions += totalCommissions;
-          existing.netPl += trade.pl - totalCommissions;
+          existing.netPl += getNetPl(trade);
           existing.tradeCount += 1;
           periodData.set(periodKey, existing);
         });
@@ -1657,6 +1657,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
 
         // Calculate totals
         const totals = {
+          reportedPl: periods.reduce((sum, p) => sum + p.reportedPl, 0),
           grossPl: periods.reduce((sum, p) => sum + p.grossPl, 0),
           commissions: periods.reduce((sum, p) => sum + p.commissions, 0),
           netPl: periods.reduce((sum, p) => sum + p.netPl, 0),
@@ -1688,6 +1689,12 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
           periodCount: periods.length,
           periods,
           totals,
+          calculationMethodology: {
+            attribution: "date_closed_fallback_date_opened",
+            reportedPl: "source_reported_basis",
+            grossPl: "gross_before_fees_reconstructed_from_declared_basis",
+            netPl: "net_after_fees_deducted_exactly_once",
+          },
         };
 
         return createToolOutput(summary, structuredData);
@@ -1947,8 +1954,9 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
               // Calculate scaling
               const btContracts = btTrade.numContracts;
               const actualContracts = actualTrade.numContracts;
+              const btNetPl = getNetPl(btTrade);
               const { scaledBtPl, scaledActualPl: actualPl } = calculateScaledPl(
-                btTrade.pl,
+                btNetPl,
                 actualTrade.pl,
                 btContracts,
                 actualContracts,
@@ -2025,9 +2033,9 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
               // P/L difference
               differences.push({
                 field: "pl",
-                backtest: btTrade.pl,
+                backtest: btNetPl,
                 actual: actualTrade.pl,
-                delta: actualTrade.pl - btTrade.pl,
+                delta: actualTrade.pl - btNetPl,
               });
 
               comparisons.push({
@@ -2035,7 +2043,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
                 strategy: btTrade.strategy,
                 timeOpened: timeKey,
                 matched: true,
-                backtestPl: btTrade.pl,
+                backtestPl: btNetPl,
                 actualPl: actualTrade.pl,
                 scaledBacktestPl: scaledBtPl,
                 slippage,
@@ -2058,17 +2066,18 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
               });
             } else {
               // Unmatched backtest trade
+              const btNetPl = getNetPl(btTrade);
               const scaledBtPl =
                 scaling === "perContract" && btTrade.numContracts > 0
-                  ? btTrade.pl / btTrade.numContracts
-                  : btTrade.pl;
+                  ? btNetPl / btTrade.numContracts
+                  : btNetPl;
 
               comparisons.push({
                 date: dateKey,
                 strategy: btTrade.strategy,
                 timeOpened: timeKey,
                 matched: false,
-                backtestPl: btTrade.pl,
+                backtestPl: btNetPl,
                 actualPl: 0,
                 scaledBacktestPl: scaledBtPl,
                 slippage: 0,
@@ -2140,7 +2149,7 @@ export function registerPerformanceTools(server: McpServer, baseDir: string): vo
               contracts: 0,
             };
             existing.trades.push(trade);
-            existing.totalPl += trade.pl;
+            existing.totalPl += getNetPl(trade);
             existing.contracts += trade.numContracts;
             backtestByDateStrategy.set(key, existing);
           });

--- a/packages/mcp-server/src/tools/reports/helpers.ts
+++ b/packages/mcp-server/src/tools/reports/helpers.ts
@@ -5,7 +5,7 @@
  * Inline implementations (can't import enrichTrades due to browser deps).
  */
 
-import type { Trade, FilterOperator } from "@tradeblocks/lib";
+import { getNetPl, type Trade, type FilterOperator } from "@tradeblocks/lib";
 
 /**
  * Simplified enriched trade interface for MCP server
@@ -114,7 +114,7 @@ export function enrichTrades(trades: Trade[]): EnrichedTrade[] {
   return trades.map((trade, index) => {
     const dateOpened = new Date(trade.dateOpened);
     const totalFees = trade.openingCommissionsFees + (trade.closingCommissionsFees ?? 0);
-    const netPl = trade.pl - totalFees;
+    const netPl = getNetPl(trade);
 
     // VIX changes
     const hasVixData = trade.openingVix != null && trade.closingVix != null;

--- a/packages/mcp-server/src/tools/shared/filters.ts
+++ b/packages/mcp-server/src/tools/shared/filters.ts
@@ -42,6 +42,20 @@ function toCalendarDateStr(date: Date | string): string {
   return `${year}-${month}-${day}`;
 }
 
+/** Return the inclusive local-calendar bounds where the supplied trades realize P/L. */
+export function realizationDateBounds(trades: Pick<Trade, "dateOpened" | "dateClosed">[]): {
+  startDate: string | null;
+  endDate: string | null;
+} {
+  if (trades.length === 0) {
+    return { startDate: null, endDate: null };
+  }
+  const dates = trades
+    .map((trade) => toCalendarDateStr(trade.dateClosed ?? trade.dateOpened))
+    .sort();
+  return { startDate: dates[0], endDate: dates[dates.length - 1] };
+}
+
 /**
  * Filter trades by date range using string comparison on Eastern Time calendar dates.
  * Avoids timezone bugs from mixing UTC Date parsing with local time setHours.

--- a/packages/mcp-server/src/tools/shared/filters.ts
+++ b/packages/mcp-server/src/tools/shared/filters.ts
@@ -63,6 +63,20 @@ export function filterByDateRange(trades: Trade[], startDate?: string, endDate?:
   return filtered;
 }
 
+/** Filter by realized P/L date: dateClosed with dateOpened only as a fallback. */
+export function filterByRealizationDateRange(
+  trades: Trade[],
+  startDate?: string,
+  endDate?: string,
+): Trade[] {
+  const start = validateDateParam(startDate);
+  const end = validateDateParam(endDate);
+  return trades.filter((trade) => {
+    const realizedDate = toCalendarDateStr(trade.dateClosed ?? trade.dateOpened);
+    return (!start || realizedDate >= start) && (!end || realizedDate <= end);
+  });
+}
+
 /**
  * Filter daily log entries by date range using string comparison on calendar dates.
  * Mirrors filterByDateRange but uses entry.date (Date object) instead of t.dateOpened.

--- a/packages/mcp-server/src/utils/batch-exit-analysis.ts
+++ b/packages/mcp-server/src/utils/batch-exit-analysis.ts
@@ -101,7 +101,10 @@ export interface AggregateStats {
   profitFactor: number;
   /** Max sequential drawdown from equity curve (cumsum of candidatePnls) */
   maxDrawdown: number;
-  /** mean/stddev of candidatePnls; null if < 2 trades */
+  /**
+   * Legacy nonannualized mean/stddev of candidatePnls; null if < 2 trades.
+   * Not comparable to daily-return Sharpe from get_statistics.
+   */
   sharpeRatio: number | null;
   maxWinStreak: number;
   maxLossStreak: number;
@@ -193,7 +196,8 @@ export function computeAggregateStats(tradeResults: TradeExitResult[]): Aggregat
     if (dd > maxDrawdown) maxDrawdown = dd;
   }
 
-  // Sharpe ratio: mean / sample stddev (N-1), null if < 2 trades
+  // Legacy trade-P/L signal-to-noise: mean / sample stddev (N-1).
+  // Retained under sharpeRatio for response compatibility; not portfolio Sharpe.
   let sharpeRatio: number | null = null;
   if (totalTrades >= 2) {
     const mean = avgPnl;

--- a/packages/mcp-server/src/utils/block-loader.ts
+++ b/packages/mcp-server/src/utils/block-loader.ts
@@ -11,8 +11,11 @@
 
 import * as fs from "fs/promises";
 import * as path from "path";
-import type { Trade, DailyLogEntry, ReportingTrade } from "@tradeblocks/lib";
 import {
+  PlBasis,
+  type Trade,
+  type DailyLogEntry,
+  type ReportingTrade,
   REPORTING_TRADE_COLUMN_ALIASES,
   isTatFormat,
   convertTatRowToReportingTrade,
@@ -192,7 +195,7 @@ function parseCSVLine(line: string): string[] {
 function convertToTrade(
   raw: Record<string, string>,
   blockId?: string,
-  defaultPlBasis: Trade["plBasis"] = "net_includes_fees",
+  defaultPlBasis: Trade["plBasis"] = PlBasis.NetIncludesFees,
 ): Trade | null {
   try {
     const dateOpened = parseDatePreservingCalendarDay(raw["Date Opened"]);
@@ -223,7 +226,7 @@ function convertToTrade(
       reasonForClose: raw["Reason For Close"] || undefined,
       pl: parseNumber(raw["P/L"]),
       plBasis:
-        raw["P/L Basis"] === "gross_before_fees" || raw["P/L Basis"] === "net_includes_fees"
+        raw["P/L Basis"] === PlBasis.GrossBeforeFees || raw["P/L Basis"] === PlBasis.NetIncludesFees
           ? raw["P/L Basis"]
           : defaultPlBasis,
       numContracts: Math.round(parseNumber(raw["No. of Contracts"], 1)),
@@ -828,6 +831,7 @@ function toKebabCase(str: string): string {
 function validateCsvColumns(
   records: Record<string, string>[],
   csvType: "tradelog" | "dailylog" | "reportinglog",
+  plBasis: PlBasis = PlBasis.NetIncludesFees,
 ): { valid: boolean; error?: string } {
   if (records.length === 0) {
     return { valid: false, error: "CSV file is empty or has no data rows" };
@@ -845,6 +849,29 @@ function validateCsvColumns(
           valid: false,
           error: `Missing required columns for tradelog: ${missing.join(", ")}. Expected columns include: Date Opened, P/L, Strategy, Legs, etc.`,
         };
+      }
+      if (plBasis === PlBasis.GrossBeforeFees) {
+        const openingFeeAliases = ["Opening Commissions + Fees", "Opening comms & fees"];
+        const closingFeeAliases = ["Closing Commissions + Fees", "Closing comms & fees"];
+        const openingFeeColumn = openingFeeAliases.find((column) => headers.includes(column));
+        const closingFeeColumn = closingFeeAliases.find((column) => headers.includes(column));
+        if (!openingFeeColumn || !closingFeeColumn) {
+          return {
+            valid: false,
+            error: "Gross-before-fees P/L requires both opening and closing commission fields",
+          };
+        }
+        const incompleteRow = records.findIndex(
+          (record) =>
+            !Number.isFinite(parseNumber(record[openingFeeColumn], NaN)) ||
+            !Number.isFinite(parseNumber(record[closingFeeColumn], NaN)),
+        );
+        if (incompleteRow >= 0) {
+          return {
+            valid: false,
+            error: `Gross-before-fees P/L requires finite opening and closing commission values (CSV row ${incompleteRow + 2})`,
+          };
+        }
       }
       break;
     }
@@ -901,7 +928,7 @@ export async function importCsv(
   options: ImportCsvOptions,
 ): Promise<ImportCsvResult> {
   const { csvPath, blockName } = options;
-  const plBasis = options.plBasis ?? "net_includes_fees";
+  const plBasis = options.plBasis ?? PlBasis.NetIncludesFees;
   let { csvType = "tradelog" } = options;
   const blocksDir = resolveBlocksBaseDir(baseDir);
 
@@ -926,7 +953,7 @@ export async function importCsv(
   }
 
   // Validate CSV has required columns
-  const validation = validateCsvColumns(records, csvType);
+  const validation = validateCsvColumns(records, csvType, plBasis);
   if (!validation.valid) {
     throw new Error(validation.error);
   }

--- a/packages/mcp-server/src/utils/block-loader.ts
+++ b/packages/mcp-server/src/utils/block-loader.ts
@@ -109,6 +109,7 @@ const KNOWN_TRADE_COLUMNS = new Set([
   "Avg. Closing Cost",
   "Reason For Close",
   "P/L",
+  "P/L Basis",
   "No. of Contracts",
   "Funds at Close",
   "Margin Req.",
@@ -188,7 +189,11 @@ function parseCSVLine(line: string): string[] {
 /**
  * Convert raw CSV record to Trade object
  */
-function convertToTrade(raw: Record<string, string>, blockId?: string): Trade | null {
+function convertToTrade(
+  raw: Record<string, string>,
+  blockId?: string,
+  defaultPlBasis: Trade["plBasis"] = "net_includes_fees",
+): Trade | null {
   try {
     const dateOpened = parseDatePreservingCalendarDay(raw["Date Opened"]);
     if (isNaN(dateOpened.getTime())) return null;
@@ -217,6 +222,10 @@ function convertToTrade(raw: Record<string, string>, blockId?: string): Trade | 
       avgClosingCost: raw["Avg. Closing Cost"] ? parseNumber(raw["Avg. Closing Cost"]) : undefined,
       reasonForClose: raw["Reason For Close"] || undefined,
       pl: parseNumber(raw["P/L"]),
+      plBasis:
+        raw["P/L Basis"] === "gross_before_fees" || raw["P/L Basis"] === "net_includes_fees"
+          ? raw["P/L Basis"]
+          : defaultPlBasis,
       numContracts: Math.round(parseNumber(raw["No. of Contracts"], 1)),
       fundsAtClose: parseNumber(raw["Funds at Close"]),
       marginReq: parseNumber(raw["Margin Req."]),
@@ -438,8 +447,8 @@ export async function listBlocks(baseDir: string): Promise<BlockInfo[]> {
         COUNT(*) as trade_count,
         MIN(t.date_opened) as min_date,
         MAX(t.date_opened) as max_date,
-        SUM(t.pl) as total_pl,
-        SUM(t.pl) - SUM(COALESCE(t.opening_commissions, 0) + COALESCE(t.closing_commissions, 0)) as net_pl
+        SUM(COALESCE(t.reported_pl, t.pl)) as total_pl,
+        SUM(t.pl) as net_pl
       FROM trades.trade_data t
       WHERE t.source IS NULL OR t.source = 'csv'
       GROUP BY t.block_id
@@ -766,6 +775,8 @@ export interface ImportCsvResult {
   };
   strategies: string[];
   blockPath: string;
+  /** Declared P/L basis persisted for imported trade logs. */
+  plBasis?: Trade["plBasis"];
 }
 
 /**
@@ -778,6 +789,24 @@ export interface ImportCsvOptions {
   blockName: string;
   /** Type of CSV data */
   csvType?: "tradelog" | "dailylog" | "reportinglog";
+  /**
+   * Basis of the P/L column for trade logs. Option Omega exports are net.
+   * Generic gross-before-fee files must declare gross_before_fees.
+   */
+  plBasis?: Trade["plBasis"];
+}
+
+function serializeCsv(records: Record<string, string>[]): string {
+  if (records.length === 0) return "";
+  const headers = Object.keys(records[0]);
+  const escapeCell = (value: string): string => {
+    if (!/[",\r\n]/.test(value)) return value;
+    return `"${value.replace(/"/g, '""')}"`;
+  };
+  return [
+    headers.map(escapeCell).join(","),
+    ...records.map((record) => headers.map((header) => escapeCell(record[header] ?? "")).join(",")),
+  ].join("\n");
 }
 
 /**
@@ -872,6 +901,7 @@ export async function importCsv(
   options: ImportCsvOptions,
 ): Promise<ImportCsvResult> {
   const { csvPath, blockName } = options;
+  const plBasis = options.plBasis ?? "net_includes_fees";
   let { csvType = "tradelog" } = options;
   const blocksDir = resolveBlocksBaseDir(baseDir);
 
@@ -934,9 +964,18 @@ export async function importCsv(
         ? "dailylog.csv"
         : "reportinglog.csv";
 
-  // Copy CSV to block directory
+  // Persist the declared P/L basis in imported trade logs so later loads do
+  // not need to infer whether commission and fee columns are already included.
   const targetPath = path.join(blockPath, targetFilename);
-  await fs.copyFile(csvPath, targetPath);
+  if (csvType === "tradelog") {
+    const recordsWithBasis = records.map((record) => ({
+      ...record,
+      "P/L Basis": plBasis,
+    }));
+    await fs.writeFile(targetPath, `${serializeCsv(recordsWithBasis)}\n`, "utf-8");
+  } else {
+    await fs.copyFile(csvPath, targetPath);
+  }
 
   // Extract metadata for return value based on CSV type
   let dateRange: { start: string | null; end: string | null } = {
@@ -949,7 +988,7 @@ export async function importCsv(
     // Parse trades to extract metadata
     const trades: Trade[] = [];
     for (const record of records) {
-      const trade = convertToTrade(record, blockName);
+      const trade = convertToTrade(record, blockName, plBasis);
       if (trade) trades.push(trade);
     }
 
@@ -1002,5 +1041,6 @@ export async function importCsv(
     dateRange,
     strategies,
     blockPath,
+    ...(csvType === "tradelog" ? { plBasis } : {}),
   };
 }

--- a/packages/mcp-server/src/utils/output-formatter.ts
+++ b/packages/mcp-server/src/utils/output-formatter.ts
@@ -33,6 +33,7 @@ export type McpContent = McpTextContent | McpResourceContent;
 export interface ToolOutput {
   [x: string]: unknown;
   content: McpContent[];
+  structuredContent?: Record<string, unknown>;
 }
 
 // Legacy alias for backward compatibility
@@ -50,6 +51,7 @@ export type DualOutput = ToolOutput;
  */
 export function createToolOutput(summary: string, data: object): ToolOutput {
   return {
+    structuredContent: data as Record<string, unknown>,
     content: [
       { type: "text", text: summary },
       {

--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -113,8 +113,18 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
             hypothesis: false,
           },
           pl: {
-            description: "Gross P&L before commissions (DOUBLE)",
+            description:
+              "Canonical net P&L after fees (DOUBLE), normalized during sync for analytics queries.",
             hypothesis: true,
+          },
+          reported_pl: {
+            description: "Source-reported P&L before basis normalization. Interpret with pl_basis.",
+            hypothesis: false,
+          },
+          pl_basis: {
+            description:
+              "P/L provenance: net_includes_fees or gross_before_fees. Use this when aggregating net performance.",
+            hypothesis: false,
           },
           date_closed: {
             description: "Trade exit date (NULL if still open)",

--- a/packages/mcp-server/tests/integration/block-diff.test.ts
+++ b/packages/mcp-server/tests/integration/block-diff.test.ts
@@ -209,17 +209,14 @@ describe("block_diff", () => {
     it("should calculate P/L delta between blocks", async () => {
       const result = await simulateBlockDiff(FIXTURES_DIR, "mock-block", "diff-block-b");
 
-      // mock-block: 200 + 250 - 150 + 430 + 250 = 980 (gross P/L)
-      // Commissions: (1.50*2)*4 + (3.00*2)*1 = 18 for mock-block
-      // Net P/L = 980 - 18 = 962
+      // Option Omega P/L is already net: 200 + 250 - 150 + 430 + 250 = 980.
+      // Commission columns are attribution and must not be deducted again.
 
-      // diff-block-b: 225 + 400 + 150 + 180 = 955 (gross P/L)
-      // Commissions: (1.50*2)*3 + (3.00*2)*1 = 15 for diff-block-b
-      // Net P/L = 955 - 15 = 940
+      // diff-block-b: 225 + 400 + 150 + 180 = 955 net P/L.
 
-      expect(result.portfolioTotals.blockA.netPl).toBeCloseTo(962, 1);
-      expect(result.portfolioTotals.blockB.netPl).toBeCloseTo(940, 1);
-      expect(result.portfolioTotals.delta.netPl).toBeCloseTo(-22, 1);
+      expect(result.portfolioTotals.blockA.netPl).toBeCloseTo(980, 1);
+      expect(result.portfolioTotals.blockB.netPl).toBeCloseTo(955, 1);
+      expect(result.portfolioTotals.delta.netPl).toBeCloseTo(-25, 1);
     });
   });
 

--- a/packages/mcp-server/tests/integration/stress-test.test.ts
+++ b/packages/mcp-server/tests/integration/stress-test.test.ts
@@ -9,7 +9,11 @@ import { fileURLToPath } from "url";
 
 // Import from built bundle (test-exports.js has @lib dependencies bundled)
 // @ts-expect-error - importing from bundled output
-import { loadBlock } from "../../src/test-exports.ts";
+import {
+  filterByRealizationDateRange,
+  loadBlock,
+  realizationDateBounds,
+} from "../../src/test-exports.ts";
 
 // @ts-expect-error - importing from bundled output
 import { PortfolioStatsCalculator } from "../../src/test-exports.ts";
@@ -80,27 +84,6 @@ const STRESS_SCENARIOS: Record<
     description: "Post 90-day tariff pause rally, S&P +9.5% single day",
   },
 };
-
-/**
- * Filter trades by date range (mirrors tool implementation)
- */
-function filterByDateRange(
-  trades: Array<{ dateOpened: Date }>,
-  startDate?: string,
-  endDate?: string,
-) {
-  let filtered = trades;
-  if (startDate) {
-    const start = new Date(startDate);
-    filtered = filtered.filter((t) => new Date(t.dateOpened) >= start);
-  }
-  if (endDate) {
-    const end = new Date(endDate);
-    end.setHours(23, 59, 59, 999);
-    filtered = filtered.filter((t) => new Date(t.dateOpened) <= end);
-  }
-  return filtered;
-}
 
 /**
  * Simulates the stress_test tool logic for testing
@@ -185,7 +168,11 @@ async function simulateStressTest(
   let scenariosWithTrades = 0;
 
   for (const scenario of scenariosToRun) {
-    const scenarioTrades = filterByDateRange(trades, scenario.startDate, scenario.endDate);
+    const scenarioTrades = filterByRealizationDateRange(
+      trades,
+      scenario.startDate,
+      scenario.endDate,
+    );
 
     if (scenarioTrades.length === 0) {
       scenarioResults.push({
@@ -423,6 +410,40 @@ describe("stress_test", () => {
       // Should include exactly the trade on 2024-01-15
       expect(result.scenarios[0].tradeCount).toBe(1);
       expect(result.scenarios[0].stats).not.toBeNull();
+    });
+
+    it("filters scenario P/L by realization date rather than entry date", () => {
+      const trades = [
+        {
+          dateOpened: new Date(2024, 0, 1),
+          dateClosed: new Date(2024, 0, 15),
+        },
+        {
+          dateOpened: new Date(2024, 0, 15),
+          dateClosed: new Date(2024, 1, 1),
+        },
+      ];
+
+      expect(filterByRealizationDateRange(trades, "2024-01-15", "2024-01-15")).toEqual([trades[0]]);
+    });
+
+    it("preserves local realization-day bounds in a positive UTC offset", () => {
+      const originalTimezone = process.env.TZ;
+      try {
+        process.env.TZ = "Asia/Tokyo";
+        const localMidnight = new Date(2024, 0, 15);
+
+        expect(realizationDateBounds([{ dateOpened: localMidnight }])).toEqual({
+          startDate: "2024-01-15",
+          endDate: "2024-01-15",
+        });
+      } finally {
+        if (originalTimezone === undefined) {
+          delete process.env.TZ;
+        } else {
+          process.env.TZ = originalTimezone;
+        }
+      }
     });
   });
 });

--- a/packages/mcp-server/tests/integration/sync-layer.test.ts
+++ b/packages/mcp-server/tests/integration/sync-layer.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "url";
 import {
   syncAllBlocks,
   syncBlock,
+  listBlocks,
   getConnection,
   closeConnection,
   upgradeToReadWrite,
@@ -401,6 +402,65 @@ describe("Sync Layer Integration", () => {
   });
 
   describe("Edge Cases", () => {
+    it("re-syncs unchanged CSVs whose metadata uses the prior parse version", async () => {
+      await createBlockWithTrades(testDir, "old-parser-block", [SAMPLE_TRADE_ROW_1]);
+      await syncAllBlocks(testDir);
+
+      const conn = await getConnection(testDir);
+      await conn.run(
+        `UPDATE trades._sync_metadata
+         SET tradelog_hash = replace(tradelog_hash, ':v3', ':v2')
+         WHERE block_id = 'old-parser-block'`,
+      );
+      await conn.run(`UPDATE trades.trade_data SET pl = -999 WHERE block_id = 'old-parser-block'`);
+
+      const result = await syncAllBlocks(testDir);
+      expect(result.blocksSynced).toBe(1);
+
+      const reader = await conn.runAndReadAll(
+        `SELECT d.pl, m.tradelog_hash
+         FROM trades.trade_data d
+         JOIN trades._sync_metadata m USING (block_id)
+         WHERE d.block_id = 'old-parser-block'`,
+      );
+      expect(Number(reader.getRows()[0][0])).toBe(200);
+      expect(String(reader.getRows()[0][1])).toMatch(/:v3$/);
+    });
+
+    it("persists gross P/L basis and reports basis-aware net P/L", async () => {
+      const blockPath = path.join(testDir, "gross-basis-block");
+      await fs.mkdir(blockPath, { recursive: true });
+      const headers = `${CSV_HEADERS.replace(
+        "Opening Commissions + Fees,Closing Commissions + Fees",
+        "Opening comms & fees,Closing comms & fees",
+      )},P/L Basis`;
+      const formattedRow = SAMPLE_TRADE_ROW_1.replace(",200,Sync", ',"$1,200.00",Sync').replace(
+        ",1.50,1.50,Target",
+        ',"$1.50","$1.50",Target',
+      );
+      await fs.writeFile(
+        path.join(blockPath, "tradelog.csv"),
+        `${headers}\n${formattedRow},gross_before_fees`,
+      );
+
+      await syncAllBlocks(testDir);
+
+      const conn = await getConnection(testDir);
+      const reader = await conn.runAndReadAll(
+        `SELECT pl_basis, pl, reported_pl
+         FROM trades.trade_data
+         WHERE block_id = 'gross-basis-block'`,
+      );
+      expect(reader.getRows()[0][0]).toBe("gross_before_fees");
+      expect(Number(reader.getRows()[0][1])).toBe(1197);
+      expect(Number(reader.getRows()[0][2])).toBe(1200);
+
+      const listed = await listBlocks(testDir);
+      const block = listed.find((entry) => entry.blockId === "gross-basis-block");
+      expect(block?.totalPl).toBe(1200);
+      expect(block?.netPl).toBe(1197);
+    });
+
     it("handles empty block folder gracefully", async () => {
       // Create empty folder (no tradelog.csv)
       const blockPath = path.join(testDir, "empty-block");

--- a/packages/mcp-server/tests/integration/sync-layer.test.ts
+++ b/packages/mcp-server/tests/integration/sync-layer.test.ts
@@ -409,7 +409,7 @@ describe("Sync Layer Integration", () => {
       const conn = await getConnection(testDir);
       await conn.run(
         `UPDATE trades._sync_metadata
-         SET tradelog_hash = replace(tradelog_hash, ':v3', ':v2')
+         SET tradelog_hash = replace(tradelog_hash, ':v4', ':v3')
          WHERE block_id = 'old-parser-block'`,
       );
       await conn.run(`UPDATE trades.trade_data SET pl = -999 WHERE block_id = 'old-parser-block'`);
@@ -424,7 +424,7 @@ describe("Sync Layer Integration", () => {
          WHERE d.block_id = 'old-parser-block'`,
       );
       expect(Number(reader.getRows()[0][0])).toBe(200);
-      expect(String(reader.getRows()[0][1])).toMatch(/:v3$/);
+      expect(String(reader.getRows()[0][1])).toMatch(/:v4$/);
     });
 
     it("persists gross P/L basis and reports basis-aware net P/L", async () => {
@@ -459,6 +459,29 @@ describe("Sync Layer Integration", () => {
       const block = listed.find((entry) => entry.blockId === "gross-basis-block");
       expect(block?.totalPl).toBe(1200);
       expect(block?.netPl).toBe(1197);
+    });
+
+    it("rejects gross-basis CSV rows when fee fields are unavailable", async () => {
+      const blockPath = path.join(testDir, "gross-without-fees-block");
+      await fs.mkdir(blockPath, { recursive: true });
+      const headers =
+        "Date Opened,Time Opened,Date Closed,Time Closed,Opening Price,Closing Price,Legs,Premium,No. of Contracts,P/L,Strategy,Reason For Close,Funds at Close,Margin Req.,P/L Basis";
+      const row =
+        "2024-01-02,09:35:00,2024-01-02,15:30:00,2.50,0.50,SPX 4800P/4750P,250,1,200,Sync Test Strategy,Target,10200,5000,gross_before_fees";
+      await fs.writeFile(path.join(blockPath, "tradelog.csv"), `${headers}\n${row}`);
+
+      const result = await syncAllBlocks(testDir);
+
+      expect(result.errors).toEqual([
+        {
+          blockId: "gross-without-fees-block",
+          error: expect.stringContaining(
+            "Gross-before-fees P/L requires both opening and closing commission fields",
+          ),
+        },
+      ]);
+      expect(await getTradeCount(testDir, "gross-without-fees-block")).toBe(0);
+      expect(await hasBlockMetadata(testDir, "gross-without-fees-block")).toBe(false);
     });
 
     it("handles empty block folder gracefully", async () => {

--- a/packages/mcp-server/tests/integration/what-if-scaling.test.ts
+++ b/packages/mcp-server/tests/integration/what-if-scaling.test.ts
@@ -5,9 +5,9 @@
  * Uses test fixture: marginal-test-block with 3 strategies (HighSharpe, Volatile, Neutral).
  *
  * Fixture data (30 trades total):
- * - HighSharpe (10 trades): Consistent wins (~$200 each), $2055 total P/L, $30 total commissions
- * - Volatile (10 trades): Big wins and losses, $1280 total P/L, $60 total commissions
- * - Neutral (10 trades): Alternating wins/losses, $200 total P/L, $30 total commissions
+ * - HighSharpe (10 trades): Consistent wins, $2055 Option Omega net P/L, $30 fees
+ * - Volatile (10 trades): Big wins/losses, $1280 Option Omega net P/L, $60 fees
+ * - Neutral (10 trades): Alternating wins/losses, $200 Option Omega net P/L, $30 fees
  *
  * CLI Test Mode Verification:
  * TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call what_if_scaling '{"blockId":"main-port-2026","strategyWeights":{"5/7 17Δ":0.5}}'
@@ -21,7 +21,14 @@ import { fileURLToPath } from "url";
 
 // Import from built bundle (test-exports.js has @lib dependencies bundled)
 // @ts-expect-error - importing from bundled output
-import { loadBlock, PortfolioStatsCalculator } from "../../src/test-exports.ts";
+import {
+  buildModifiedTrades,
+  filterByRealizationDateRange,
+  getNetPl,
+  loadBlock,
+  PortfolioStatsCalculator,
+  rebuildCounterfactualBaseline,
+} from "../../src/test-exports.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,32 +40,12 @@ interface Trade {
   pl: number;
   openingCommissionsFees: number;
   closingCommissionsFees: number;
+  plBasis?: "net_includes_fees" | "gross_before_fees";
   dateOpened: Date;
+  dateClosed?: Date;
+  timeClosed?: string;
+  fundsAtClose: number;
   [key: string]: unknown;
-}
-
-/**
- * Filter trades by date range (matching tool implementation)
- */
-function filterByDateRange(trades: Trade[], startDate?: string, endDate?: string): Trade[] {
-  let filtered = trades;
-
-  if (startDate) {
-    const start = new Date(startDate);
-    if (!isNaN(start.getTime())) {
-      filtered = filtered.filter((t) => new Date(t.dateOpened) >= start);
-    }
-  }
-
-  if (endDate) {
-    const end = new Date(endDate);
-    if (!isNaN(end.getTime())) {
-      end.setHours(23, 59, 59, 999);
-      filtered = filtered.filter((t) => new Date(t.dateOpened) <= end);
-    }
-  }
-
-  return filtered;
 }
 
 /**
@@ -80,7 +67,7 @@ async function simulateWhatIfScaling(
   let trades: Trade[] = block.trades;
 
   // Apply date range filter
-  trades = filterByDateRange(trades, startDate, endDate);
+  trades = filterByRealizationDateRange(trades, startDate, endDate);
 
   if (trades.length === 0) {
     return {
@@ -121,7 +108,11 @@ async function simulateWhatIfScaling(
   }
 
   // Calculate original (baseline) portfolio metrics
-  const baselineStats = calculator.calculatePortfolioStats(trades, undefined, true);
+  const baselineStats = calculator.calculatePortfolioStats(
+    rebuildCounterfactualBaseline(trades),
+    undefined,
+    true,
+  );
 
   // Build scaled trades
   type ScaledTrade = Trade & {
@@ -148,12 +139,7 @@ async function simulateWhatIfScaling(
   }
 
   // Create modified trades for scaled portfolio
-  const modifiedTrades: Trade[] = scaledTrades.map((st) => ({
-    ...st,
-    pl: st.scaledPl,
-    openingCommissionsFees: st.scaledOpeningComm,
-    closingCommissionsFees: st.scaledClosingComm,
-  }));
+  const modifiedTrades = buildModifiedTrades(scaledTrades, trades) as Trade[];
 
   // Calculate scaled portfolio metrics
   const scaledStats = calculator.calculatePortfolioStats(modifiedTrades, undefined, true);
@@ -189,7 +175,7 @@ async function simulateWhatIfScaling(
       originalByStrategy[trade.strategy] = { trades: 0, netPl: 0 };
     }
     originalByStrategy[trade.strategy].trades++;
-    const netPl = trade.pl - trade.openingCommissionsFees - trade.closingCommissionsFees;
+    const netPl = getNetPl(trade);
     originalByStrategy[trade.strategy].netPl += netPl;
     totalOriginalPl += netPl;
   }
@@ -200,7 +186,12 @@ async function simulateWhatIfScaling(
       scaledByStrategy[st.strategy] = { trades: 0, netPl: 0 };
     }
     scaledByStrategy[st.strategy].trades++;
-    const netPl = st.scaledPl - st.scaledOpeningComm - st.scaledClosingComm;
+    const netPl = getNetPl({
+      ...st,
+      pl: st.scaledPl,
+      openingCommissionsFees: st.scaledOpeningComm,
+      closingCommissionsFees: st.scaledClosingComm,
+    });
     scaledByStrategy[st.strategy].netPl += netPl;
     totalScaledPl += netPl;
   }
@@ -263,6 +254,23 @@ async function simulateWhatIfScaling(
 }
 
 describe("what_if_scaling", () => {
+  it("includes open-before/close-inside trades and excludes open-inside/close-after trades", () => {
+    const trades = [
+      {
+        strategy: "A",
+        dateOpened: new Date(2025, 11, 31),
+        dateClosed: new Date(2026, 0, 2),
+      },
+      {
+        strategy: "B",
+        dateOpened: new Date(2026, 0, 2),
+        dateClosed: new Date(2026, 0, 4),
+      },
+    ] as Trade[];
+
+    expect(filterByRealizationDateRange(trades, "2026-01-01", "2026-01-03")).toEqual([trades[0]]);
+  });
+
   describe("no weights (baseline = scaled)", () => {
     it("should return identical metrics when no weights specified", async () => {
       const result = await simulateWhatIfScaling(FIXTURES_DIR, "marginal-test-block");
@@ -300,7 +308,8 @@ describe("what_if_scaling", () => {
 
       const highSharpe = result.perStrategy?.find((s) => s.strategy === "HighSharpe");
       expect(highSharpe?.weight).toBe(0.5);
-      // Net P/L should be halved (approximately, accounting for scaled commissions)
+      expect(highSharpe?.original.netPl).toBe(2055);
+      expect(highSharpe?.scaled.netPl).toBe(1027.5);
       expect(highSharpe?.scaled.netPl).toBeCloseTo(highSharpe!.original.netPl * 0.5, 1);
       expect(highSharpe?.delta.netPlPct).toBeCloseTo(-50, 1);
     });
@@ -330,6 +339,32 @@ describe("what_if_scaling", () => {
         baseline.comparison?.netPl.original ?? 0,
       );
     });
+  });
+
+  it("rebuilds gross-basis scaled equity from net P/L", () => {
+    const original = {
+      strategy: "Gross",
+      pl: 110,
+      plBasis: "gross_before_fees" as const,
+      openingCommissionsFees: 5,
+      closingCommissionsFees: 5,
+      dateOpened: new Date("2026-01-02"),
+      dateClosed: new Date("2026-01-02"),
+      timeClosed: "15:55:00",
+      fundsAtClose: 1100,
+    } as Trade;
+    const scaled = {
+      ...original,
+      scaledPl: 55,
+      scaledOpeningComm: 2.5,
+      scaledClosingComm: 2.5,
+      weight: 0.5,
+    };
+
+    const [modified] = buildModifiedTrades([scaled], [original]);
+
+    expect(getNetPl(modified)).toBe(50);
+    expect(modified.fundsAtClose).toBe(1050);
   });
 
   describe("single strategy 2.0x", () => {

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -209,6 +209,30 @@ describe("block-loader", () => {
         expect(imported.trades.every((trade) => trade.plBasis === "gross_before_fees")).toBe(true);
       });
     });
+
+    it("rejects gross-before-fees imports without commission fields", async () => {
+      await withNestedBlocksFixture(async (dataRoot) => {
+        const sourceCsv = path.join(dataRoot, "gross-without-fees.csv");
+        await fs.writeFile(
+          sourceCsv,
+          ["Date Opened,P/L,Strategy", "2024-01-02,200,Gross Strategy"].join("\n"),
+        );
+
+        await expect(
+          importCsv(dataRoot, {
+            csvPath: sourceCsv,
+            blockName: "Gross Without Fees",
+            csvType: "tradelog",
+            plBasis: "gross_before_fees",
+          }),
+        ).rejects.toThrow(
+          "Gross-before-fees P/L requires both opening and closing commission fields",
+        );
+        await expect(
+          fs.access(path.join(dataRoot, "blocks", "gross-without-fees")),
+        ).rejects.toThrow();
+      });
+    });
   });
 
   describe("trade data validation", () => {

--- a/packages/mcp-server/tests/tools.test.ts
+++ b/packages/mcp-server/tests/tools.test.ts
@@ -14,7 +14,17 @@ import { fileURLToPath } from "url";
 
 // Import from built bundle (test-exports.js has @lib dependencies bundled)
 // @ts-expect-error - importing from bundled output
-import { loadBlock, listBlocks, importCsv, closeConnection } from "../src/test-exports.ts";
+import {
+  filterByRealizationDateRange,
+  calculatePeakExposure,
+  buildEquityCurve,
+  buildMonthlyReturns,
+  rebuildSubsetEquity,
+  loadBlock,
+  listBlocks,
+  importCsv,
+  closeConnection,
+} from "../src/test-exports.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -174,15 +184,148 @@ describe("block-loader", () => {
         });
 
         expect(result.blockId).toBe("imported-block");
+        expect(result.plBasis).toBe("net_includes_fees");
         await expect(
           fs.access(path.join(dataRoot, "blocks", "imported-block", "tradelog.csv")),
         ).resolves.toBeUndefined();
+        const imported = await loadBlock(dataRoot, "imported-block");
+        expect(imported.trades.every((trade) => trade.plBasis === "net_includes_fees")).toBe(true);
         await expect(fs.access(path.join(dataRoot, "imported-block"))).rejects.toThrow();
+      });
+    });
+
+    it("persists an explicit gross-before-fees basis for generic trade logs", async () => {
+      await withNestedBlocksFixture(async (dataRoot) => {
+        const sourceCsv = path.join(FIXTURES_DIR, "nonstandard-name", "my-custom-trades.csv");
+        const result = await importCsv(dataRoot, {
+          csvPath: sourceCsv,
+          blockName: "Gross Imported Block",
+          csvType: "tradelog",
+          plBasis: "gross_before_fees",
+        });
+
+        expect(result.plBasis).toBe("gross_before_fees");
+        const imported = await loadBlock(dataRoot, result.blockId);
+        expect(imported.trades.every((trade) => trade.plBasis === "gross_before_fees")).toBe(true);
       });
     });
   });
 
   describe("trade data validation", () => {
+    it("filters realized P/L by close date without UTC boundary drift", () => {
+      const trades = [
+        {
+          dateOpened: new Date(2025, 11, 31),
+          dateClosed: new Date(2026, 0, 1),
+        },
+      ] as Awaited<ReturnType<typeof loadBlock>>["trades"];
+
+      expect(filterByRealizationDateRange(trades, "2026-01-01", "2026-01-01")).toHaveLength(1);
+      expect(filterByRealizationDateRange(trades, "2025-12-31", "2025-12-31")).toHaveLength(0);
+    });
+
+    it("rebuilds strategy-subset equity without excluded portfolio losses", () => {
+      const base = {
+        openingCommissionsFees: 0,
+        closingCommissionsFees: 0,
+        plBasis: "net_includes_fees" as const,
+      };
+      const allTrades = [
+        {
+          ...base,
+          strategy: "A",
+          dateOpened: new Date(2026, 0, 1),
+          dateClosed: new Date(2026, 0, 1),
+          pl: 100,
+          fundsAtClose: 10100,
+        },
+        {
+          ...base,
+          strategy: "B",
+          dateOpened: new Date(2026, 0, 2),
+          dateClosed: new Date(2026, 0, 2),
+          pl: -5000,
+          fundsAtClose: 5100,
+        },
+        {
+          ...base,
+          strategy: "A",
+          dateOpened: new Date(2026, 0, 3),
+          dateClosed: new Date(2026, 0, 3),
+          pl: 100,
+          fundsAtClose: 5200,
+        },
+      ] as Awaited<ReturnType<typeof loadBlock>>["trades"];
+      const subset = allTrades.filter((trade) => trade.strategy === "A");
+
+      const rebuilt = rebuildSubsetEquity(subset, allTrades);
+
+      expect(rebuilt.map((trade) => trade.fundsAtClose)).toEqual([10100, 10200]);
+    });
+
+    it("uses net P/L for gross-basis peak exposure percentages", () => {
+      const trades = [
+        {
+          strategy: "Gross",
+          dateOpened: new Date(2026, 0, 1),
+          dateClosed: new Date(2026, 0, 1),
+          timeOpened: "09:30:00",
+          timeClosed: "16:00:00",
+          pl: 110,
+          plBasis: "gross_before_fees",
+          openingCommissionsFees: 5,
+          closingCommissionsFees: 5,
+          fundsAtClose: 1100,
+          marginReq: 0,
+        },
+        {
+          strategy: "Gross",
+          dateOpened: new Date(2026, 0, 2),
+          dateClosed: new Date(2026, 0, 2),
+          timeOpened: "09:30:00",
+          timeClosed: "16:00:00",
+          pl: 0,
+          plBasis: "gross_before_fees",
+          openingCommissionsFees: 0,
+          closingCommissionsFees: 0,
+          fundsAtClose: 1100,
+          marginReq: 550,
+        },
+      ] as Awaited<ReturnType<typeof loadBlock>>["trades"];
+
+      const peak = calculatePeakExposure(trades, 1000);
+
+      expect(peak.peakByPercent?.exposurePercent).toBe(50);
+    });
+
+    it("charts gross-basis P/L on its net realization date", () => {
+      const trades = [
+        {
+          strategy: "Gross",
+          dateOpened: new Date(2026, 0, 31),
+          dateClosed: new Date(2026, 1, 1),
+          timeOpened: "09:30:00",
+          timeClosed: "16:00:00",
+          pl: 110,
+          plBasis: "gross_before_fees",
+          openingCommissionsFees: 5,
+          closingCommissionsFees: 5,
+          fundsAtClose: 1100,
+          marginReq: 100,
+        },
+      ] as Awaited<ReturnType<typeof loadBlock>>["trades"];
+
+      const curve = buildEquityCurve(trades);
+      const monthly = buildMonthlyReturns(trades);
+
+      expect(curve).toMatchObject([
+        { date: "2026-02-01", equity: 1000 },
+        { date: "2026-02-01", equity: 1100 },
+      ]);
+      expect(monthly[2026][1]).toBe(0);
+      expect(monthly[2026][2]).toBe(100);
+    });
+
     it("should parse P/L correctly", async () => {
       const block = await loadBlock(FIXTURES_DIR, "mock-block");
 

--- a/packages/mcp-server/tests/unit/output-formatter.test.ts
+++ b/packages/mcp-server/tests/unit/output-formatter.test.ts
@@ -1,0 +1,26 @@
+import { createToolOutput } from "../../src/utils/output-formatter.ts";
+
+describe("createToolOutput", () => {
+  it("returns authoritative structuredContent while preserving legacy content", () => {
+    const data = {
+      stats: { netPl: 10704.08, sharpeRatio: 1.2 },
+      calculationMethodology: {
+        pnl: { sourceBasis: "net_includes_fees" },
+        sharpe: { riskFreeRate: { mode: "fixed", annualRatePct: 2 } },
+      },
+    };
+
+    const output = createToolOutput("Stats ready", data);
+
+    expect(output.structuredContent).toEqual(data);
+    expect(output.content[0]).toEqual({ type: "text", text: "Stats ready" });
+    expect(output.content[1]).toMatchObject({
+      type: "resource",
+      resource: {
+        uri: "data:application/json",
+        mimeType: "application/json",
+        text: JSON.stringify(data),
+      },
+    });
+  });
+});

--- a/releases/v3.7.0.md
+++ b/releases/v3.7.0.md
@@ -1,5 +1,20 @@
 # Tradeblocks 3.7.0
 
+## Metric provenance and Sharpe re-baselining
+
+Trade P/L now declares whether its source value already includes fees. Option
+Omega exports are treated as net P/L, so their separate fee columns remain
+informational and are not deducted a second time. Gross-before-fees imports
+must explicitly select that basis and provide both commission fields.
+
+Sharpe and Sortino now use sample standard deviation and expose their applied
+risk-free-rate methodology. This corrects the former population-standard-
+deviation calculation and therefore changes historical Sharpe values. Re-baseline
+saved comparisons, alert thresholds, and report commentary when upgrading.
+Callers can provide `riskFreeRateAnnualPct` in annual percentage points (for
+example, `2.5` means 2.5%); otherwise the historical DTB3 series remains the
+default.
+
 ## Parameter-study selection evidence
 
 `@tradeblocks/lib/calculations` now exports

--- a/tests/integration/indexeddb-data-loader.test.ts
+++ b/tests/integration/indexeddb-data-loader.test.ts
@@ -177,6 +177,32 @@ describe("IndexedDB Integration with Data Loader", () => {
   });
 
   describe("DataLoader with IndexedDBAdapter", () => {
+    test("should stamp pre-provenance Option Omega rows as net on read", async () => {
+      const blockId = "test-block-3";
+      await tradesStore.addTrades(blockId, [
+        {
+          dateOpened: new Date("2024-01-01"),
+          timeOpened: "10:00:00",
+          openingPrice: 100,
+          legs: "CALL",
+          premium: 500,
+          pl: 100,
+          numContracts: 1,
+          fundsAtClose: 10100,
+          marginReq: 1000,
+          strategy: "Legacy OO row",
+          openingCommissionsFees: 1,
+          closingCommissionsFees: 1,
+          openingShortLongRatio: 0.5,
+        },
+      ]);
+
+      const adapter = new IndexedDBAdapter();
+      const [restored] = await adapter.getTrades(blockId);
+
+      expect(restored.plBasis).toBe("net_includes_fees");
+    });
+
     test("should load and store data using IndexedDB adapter", async () => {
       const adapter = new IndexedDBAdapter();
       const loader = new DataLoader({

--- a/tests/unit/comprehensive-portfolio-stats.test.ts
+++ b/tests/unit/comprehensive-portfolio-stats.test.ts
@@ -138,11 +138,11 @@ describe("Comprehensive Portfolio Statistics", () => {
       expect(stats.totalTrades).toBe(4);
       expect(stats.totalPl).toBe(275); // 150 - 75 + 200 + 0
       expect(stats.winningTrades).toBe(2);
-      expect(stats.losingTrades).toBe(1);
-      expect(stats.breakEvenTrades).toBe(1);
+      expect(stats.losingTrades).toBe(2);
+      expect(stats.breakEvenTrades).toBe(0);
       expect(stats.winRate).toBeCloseTo(0.5, 2); // 2/4
-      expect(stats.avgWin).toBeCloseTo(175, 2); // (150 + 200) / 2
-      expect(stats.avgLoss).toBe(-75);
+      expect(stats.avgWin).toBeCloseTo(163, 2);
+      expect(stats.avgLoss).toBeCloseTo(-55.5, 2);
     });
 
     test("should handle empty portfolio", () => {
@@ -169,7 +169,7 @@ describe("Comprehensive Portfolio Statistics", () => {
       expect(stats.winningTrades).toBe(2);
       expect(stats.losingTrades).toBe(0);
       expect(stats.winRate).toBe(1.0);
-      expect(stats.avgWin).toBe(175);
+      expect(stats.avgWin).toBe(163);
     });
 
     test("should filter by Strategy B", () => {
@@ -181,7 +181,7 @@ describe("Comprehensive Portfolio Statistics", () => {
       expect(stats.winningTrades).toBe(0);
       expect(stats.losingTrades).toBe(1);
       expect(stats.winRate).toBe(0);
-      expect(stats.avgLoss).toBe(-75);
+      expect(stats.avgLoss).toBe(-95);
     });
 
     test("should handle break-even trades separately", () => {
@@ -190,9 +190,9 @@ describe("Comprehensive Portfolio Statistics", () => {
 
       expect(stats.totalTrades).toBe(1);
       expect(stats.totalPl).toBe(0);
-      expect(stats.breakEvenTrades).toBe(1);
+      expect(stats.breakEvenTrades).toBe(0);
       expect(stats.winningTrades).toBe(0);
-      expect(stats.losingTrades).toBe(0);
+      expect(stats.losingTrades).toBe(1);
     });
   });
 

--- a/tests/unit/data-loader.test.ts
+++ b/tests/unit/data-loader.test.ts
@@ -96,6 +96,7 @@ describe("Data Loader", () => {
       expect(result.data).toHaveLength(1);
       expect(result.errors).toHaveLength(0);
       expect(result.data[0].pl).toBe(100);
+      expect(result.data[0].plBasis).toBe("net_includes_fees");
       expect(result.data[0].strategy).toBe("Test Strategy");
     });
 

--- a/tests/unit/metric-contract.test.ts
+++ b/tests/unit/metric-contract.test.ts
@@ -1,0 +1,375 @@
+import {
+  combineAllLegGroups,
+  combineLegGroup,
+  getNetPl,
+  PerformanceCalculator,
+  PortfolioStatsCalculator,
+  type DailyLogEntry,
+  type Trade,
+} from "@tradeblocks/lib";
+
+function trade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    dateOpened: new Date("2026-01-02"),
+    timeOpened: "09:32:00",
+    openingPrice: 0,
+    legs: "SPX test spread",
+    premium: 0,
+    dateClosed: new Date("2026-01-02"),
+    timeClosed: "15:55:00",
+    pl: 100,
+    numContracts: 1,
+    fundsAtClose: 100100,
+    marginReq: 1000,
+    strategy: "OO parity",
+    openingCommissionsFees: 1,
+    closingCommissionsFees: 1,
+    openingShortLongRatio: 0,
+    ...overrides,
+  };
+}
+
+describe("P/L and Sharpe calculation contract", () => {
+  it("does not deduct Option Omega fees a second time", () => {
+    const trades = [
+      trade({
+        pl: 231.44,
+        plBasis: "net_includes_fees",
+        openingCommissionsFees: 1.78,
+        closingCommissionsFees: 1.78,
+      }),
+      trade({
+        dateOpened: new Date("2026-01-05"),
+        dateClosed: new Date("2026-01-05"),
+        pl: -305.12,
+        plBasis: "net_includes_fees",
+        openingCommissionsFees: 2.56,
+        closingCommissionsFees: 2.56,
+        fundsAtClose: 99726.32,
+      }),
+    ];
+
+    const stats = new PortfolioStatsCalculator().calculatePortfolioStats(trades);
+
+    expect(stats.totalPl).toBeCloseTo(-73.68, 8);
+    expect(stats.netPl).toBeCloseTo(-73.68, 8);
+    expect(stats.totalCommissions).toBeCloseTo(8.68, 8);
+    expect(getNetPl(trades[0])).toBe(231.44);
+  });
+
+  it("keeps the legacy undeclared gross contract and deducts fees once", () => {
+    const grossTrade = trade({
+      pl: 235,
+      openingCommissionsFees: 1.78,
+      closingCommissionsFees: 1.78,
+    });
+
+    const stats = new PortfolioStatsCalculator().calculatePortfolioStats([grossTrade]);
+
+    expect(stats.totalPl).toBe(235);
+    expect(stats.netPl).toBeCloseTo(231.44, 8);
+    expect(getNetPl(grossTrade)).toBeCloseTo(231.44, 8);
+  });
+
+  it("uses the same net derived metrics for undeclared and explicit gross P/L", () => {
+    const trades = [
+      trade({ pl: 110, openingCommissionsFees: 5, closingCommissionsFees: 5 }),
+      trade({
+        dateOpened: new Date("2026-01-05"),
+        dateClosed: new Date("2026-01-05"),
+        pl: -40,
+        openingCommissionsFees: 5,
+        closingCommissionsFees: 5,
+      }),
+      trade({
+        dateOpened: new Date("2026-01-06"),
+        dateClosed: new Date("2026-01-06"),
+        pl: 60,
+        openingCommissionsFees: 5,
+        closingCommissionsFees: 5,
+      }),
+    ];
+    const explicit = trades.map((item) => ({
+      ...item,
+      plBasis: "gross_before_fees" as const,
+    }));
+    const calculator = new PortfolioStatsCalculator({ riskFreeRateAnnualPct: 0 });
+    const undeclaredStats = calculator.calculatePortfolioStats(trades);
+    const explicitStats = calculator.calculatePortfolioStats(explicit);
+
+    expect(undeclaredStats.netPl).toBe(explicitStats.netPl);
+    expect(undeclaredStats.profitFactor).toBe(explicitStats.profitFactor);
+    expect(undeclaredStats.sharpeRatio).toBe(explicitStats.sharpeRatio);
+    expect(undeclaredStats.sortinoRatio).toBe(explicitStats.sortinoRatio);
+  });
+
+  it("normalizes mixed-basis leg groups to one net basis", () => {
+    const combined = combineLegGroup([
+      trade({
+        pl: 100,
+        plBasis: "net_includes_fees",
+        legs: "call spread",
+        openingCommissionsFees: 2,
+        closingCommissionsFees: 2,
+      }),
+      trade({
+        pl: 100,
+        plBasis: "gross_before_fees",
+        legs: "put spread",
+        openingCommissionsFees: 3,
+        closingCommissionsFees: 3,
+      }),
+    ]);
+
+    expect(combined.plBasis).toBe("net_includes_fees");
+    expect(combined.pl).toBe(194);
+    expect(getNetPl(combined)).toBe(194);
+  });
+
+  it("preserves OO metrics when paired entry legs are grouped", () => {
+    let runningFunds = 100000;
+    const rawTrades = [100, -40, 80, -20].flatMap((groupPl, index) => {
+      const date = new Date(2026, 0, 5 + index);
+      const legs = [
+        trade({
+          dateOpened: date,
+          dateClosed: date,
+          timeOpened: "09:40:00",
+          timeClosed: "15:54:00",
+          strategy: "Grouped OO",
+          legs: "call spread",
+          pl: groupPl * 0.6,
+          plBasis: "net_includes_fees",
+          openingCommissionsFees: 1.78,
+          closingCommissionsFees: 0.78,
+        }),
+        trade({
+          dateOpened: date,
+          dateClosed: date,
+          timeOpened: "09:40:00",
+          timeClosed: "15:55:00",
+          strategy: "Grouped OO",
+          legs: "put spread",
+          pl: groupPl * 0.4,
+          plBasis: "net_includes_fees",
+          openingCommissionsFees: 1.78,
+          closingCommissionsFees: 0.78,
+        }),
+      ];
+      return legs.map((item) => {
+        runningFunds += item.pl;
+        return { ...item, fundsAtClose: runningFunds };
+      });
+    });
+    const grouped = combineAllLegGroups(rawTrades);
+    const calculator = new PortfolioStatsCalculator({ riskFreeRateAnnualPct: 2.5 });
+    const rawStats = calculator.calculatePortfolioStats(rawTrades);
+    const groupedStats = calculator.calculatePortfolioStats(grouped);
+
+    expect(grouped).toHaveLength(4);
+    expect(grouped.every((item) => item.plBasis === "net_includes_fees")).toBe(true);
+    expect(groupedStats.netPl).toBeCloseTo(rawStats.netPl, 10);
+    expect(groupedStats.totalCommissions).toBeCloseTo(rawStats.totalCommissions, 10);
+    expect(groupedStats.sharpeRatio).toBeCloseTo(rawStats.sharpeRatio!, 10);
+    expect(groupedStats.sortinoRatio).toBeCloseTo(rawStats.sortinoRatio!, 10);
+  });
+
+  it("uses sample N-1 volatility and echoes a fixed annual RFR", () => {
+    const trades = [
+      trade({ pl: 1000, plBasis: "net_includes_fees" }),
+      trade({
+        dateOpened: new Date("2026-01-05"),
+        dateClosed: new Date("2026-01-05"),
+        pl: -505,
+        plBasis: "net_includes_fees",
+      }),
+      trade({
+        dateOpened: new Date("2026-01-06"),
+        dateClosed: new Date("2026-01-06"),
+        pl: 1004.95,
+        plBasis: "net_includes_fees",
+      }),
+    ];
+    const dailyLogs: DailyLogEntry[] = [
+      {
+        date: new Date("2026-01-02"),
+        netLiquidity: 101000,
+        currentFunds: 101000,
+        withdrawn: 0,
+        tradingFunds: 101000,
+        dailyPl: 1000,
+        dailyPlPct: 1,
+        drawdownPct: 0,
+      },
+      {
+        date: new Date("2026-01-05"),
+        netLiquidity: 100495,
+        currentFunds: 100495,
+        withdrawn: 0,
+        tradingFunds: 100495,
+        dailyPl: -505,
+        dailyPlPct: -0.5,
+        drawdownPct: -0.5,
+      },
+      {
+        date: new Date("2026-01-06"),
+        netLiquidity: 101499.95,
+        currentFunds: 101499.95,
+        withdrawn: 0,
+        tradingFunds: 101499.95,
+        dailyPl: 1004.95,
+        dailyPlPct: 1,
+        drawdownPct: 0,
+      },
+    ];
+    const calculator = new PortfolioStatsCalculator({ riskFreeRateAnnualPct: 0 });
+    const stats = calculator.calculatePortfolioStats(trades, dailyLogs);
+    const expectedSampleStd = Math.sqrt(
+      ((0.01 - 0.005) ** 2 + (-0.005 - 0.005) ** 2 + (0.01 - 0.005) ** 2) / 2,
+    );
+    const expectedSharpe = (0.005 / expectedSampleStd) * Math.sqrt(252);
+
+    expect(stats.sharpeRatio).toBeCloseTo(expectedSharpe, 10);
+
+    const methodology = calculator.getCalculationMethodology(trades, dailyLogs);
+    expect(methodology.sharpe.volatilityEstimator).toBe("sample_standard_deviation_n_minus_1");
+    expect(methodology.sharpe.riskFreeRate).toEqual({
+      mode: "fixed",
+      annualRatePct: 0,
+    });
+    expect(methodology.sortino).toEqual({
+      annualizationFactor: 252,
+      downsideTarget: "zero_excess_return",
+      observationSet: "all_return_observations_positive_values_contribute_zero",
+      denominator: "total_observations_n",
+      riskFreeRate: "same_daily_rate_as_sharpe",
+    });
+    expect(methodology.returns).toMatchObject({
+      source: "daily_log",
+      observations: 3,
+      idleDays: "included_as_provided",
+    });
+  });
+
+  it("matches the reduced OO display benchmark at a fixed 2.5% RFR", () => {
+    // Synthetic excess-return shape reduced from the supplied OO parity case.
+    // It locks the two independently displayed rounded risk metrics without
+    // committing the user's trade or portfolio logs.
+    const excessReturns = [
+      -0.01, -0.01, 0.021984978900273847, 0.0006599291968471125, 0.0006599291968471125,
+      0.0006599291968471125, 0.0006599291968471125, 0.0006599291968471125, 0.0006599291968471125,
+      0.0006599291968471125,
+    ];
+    const dailyRiskFreeRate = 0.025 / 252;
+    let previousValue = 100000;
+    const dates = [
+      "2026-01-05",
+      "2026-01-06",
+      "2026-01-07",
+      "2026-01-08",
+      "2026-01-09",
+      "2026-01-12",
+      "2026-01-13",
+      "2026-01-14",
+      "2026-01-15",
+      "2026-01-16",
+    ];
+    const dailyLogs: DailyLogEntry[] = excessReturns.map((excessReturn, index) => {
+      const dailyPl = previousValue * (excessReturn + dailyRiskFreeRate);
+      previousValue += dailyPl;
+      return {
+        date: new Date(dates[index]),
+        netLiquidity: previousValue,
+        currentFunds: previousValue,
+        withdrawn: 0,
+        tradingFunds: previousValue,
+        dailyPl,
+        dailyPlPct: 0,
+        drawdownPct: 0,
+      };
+    });
+    const trades = dates.map((date, index) =>
+      trade({
+        dateOpened: new Date(date),
+        dateClosed: new Date(date),
+        pl: dailyLogs[index].dailyPl,
+        fundsAtClose: dailyLogs[index].netLiquidity,
+        plBasis: "net_includes_fees",
+      }),
+    );
+
+    const stats = new PortfolioStatsCalculator({
+      riskFreeRateAnnualPct: 2.5,
+    }).calculatePortfolioStats(trades, dailyLogs);
+
+    expect(stats.sharpeRatio).toBeCloseTo(1.20437, 5);
+    expect(stats.sortinoRatio).toBeCloseTo(2.344359, 5);
+    expect(stats.sharpeRatio?.toFixed(1)).toBe("1.2");
+    expect(stats.sortinoRatio?.toFixed(2)).toBe("2.34");
+  });
+
+  it("inserts zero-P/L weekdays for trade-only annualization", () => {
+    const trades = [
+      trade({ dateClosed: new Date("2026-01-05"), plBasis: "net_includes_fees" }),
+      trade({
+        dateOpened: new Date("2026-01-16"),
+        dateClosed: new Date("2026-01-16"),
+        pl: -50,
+        plBasis: "net_includes_fees",
+      }),
+    ];
+
+    const methodology = new PortfolioStatsCalculator({
+      riskFreeRateAnnualPct: 0,
+    }).getCalculationMethodology(trades);
+
+    expect(methodology.returns).toMatchObject({
+      source: "realized_trade_pl",
+      observations: 10,
+      idleDays: "included_business_days",
+    });
+  });
+
+  it("discloses rolling windows as realized-trade dates rather than days", () => {
+    const trades = [
+      trade({ dateClosed: new Date("2026-01-05"), plBasis: "net_includes_fees" }),
+      trade({
+        dateOpened: new Date("2026-01-16"),
+        dateClosed: new Date("2026-01-16"),
+        pl: -50,
+        plBasis: "net_includes_fees",
+      }),
+    ];
+
+    const [point] = PerformanceCalculator.calculateRollingSharpe(trades, 2, 0);
+
+    expect(point.windowDefinition).toBe("distinct_realized_trade_dates");
+    expect(point.requestedWindowSize).toBe(2);
+    expect(point.calculationMethodology.returns.observations).toBe(10);
+    expect(point.calculationMethodology.warnings.join(" ")).toContain(
+      "2 distinct realized-trade dates",
+    );
+  });
+
+  it("discloses stale historical DTB3 observations", () => {
+    const trades = [
+      trade({ dateClosed: new Date("2099-01-05"), plBasis: "net_includes_fees" }),
+      trade({
+        dateOpened: new Date("2099-01-06"),
+        dateClosed: new Date("2099-01-06"),
+        plBasis: "net_includes_fees",
+      }),
+    ];
+
+    const methodology = new PortfolioStatsCalculator().getCalculationMethodology(trades);
+
+    expect(methodology.returns.attribution).toBe("date_closed_fallback_date_opened");
+    expect(methodology.returns.idleDays).toBe("included_business_days");
+    expect(methodology.sharpe.riskFreeRate).toMatchObject({
+      mode: "historical",
+      series: "FRED_DTB3",
+      resolutionCounts: { staleAfterLatest: 2 },
+    });
+    expect(methodology.warnings.join(" ")).toContain("latest available DTB3 rate");
+  });
+});

--- a/tests/unit/metric-contract.test.ts
+++ b/tests/unit/metric-contract.test.ts
@@ -2,6 +2,7 @@ import {
   combineAllLegGroups,
   combineLegGroup,
   getNetPl,
+  PlBasis,
   PerformanceCalculator,
   PortfolioStatsCalculator,
   type DailyLogEntry,
@@ -34,7 +35,7 @@ describe("P/L and Sharpe calculation contract", () => {
     const trades = [
       trade({
         pl: 231.44,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
         openingCommissionsFees: 1.78,
         closingCommissionsFees: 1.78,
       }),
@@ -42,7 +43,7 @@ describe("P/L and Sharpe calculation contract", () => {
         dateOpened: new Date("2026-01-05"),
         dateClosed: new Date("2026-01-05"),
         pl: -305.12,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
         openingCommissionsFees: 2.56,
         closingCommissionsFees: 2.56,
         fundsAtClose: 99726.32,
@@ -91,7 +92,7 @@ describe("P/L and Sharpe calculation contract", () => {
     ];
     const explicit = trades.map((item) => ({
       ...item,
-      plBasis: "gross_before_fees" as const,
+      plBasis: PlBasis.GrossBeforeFees,
     }));
     const calculator = new PortfolioStatsCalculator({ riskFreeRateAnnualPct: 0 });
     const undeclaredStats = calculator.calculatePortfolioStats(trades);
@@ -107,14 +108,14 @@ describe("P/L and Sharpe calculation contract", () => {
     const combined = combineLegGroup([
       trade({
         pl: 100,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
         legs: "call spread",
         openingCommissionsFees: 2,
         closingCommissionsFees: 2,
       }),
       trade({
         pl: 100,
-        plBasis: "gross_before_fees",
+        plBasis: PlBasis.GrossBeforeFees,
         legs: "put spread",
         openingCommissionsFees: 3,
         closingCommissionsFees: 3,
@@ -139,7 +140,7 @@ describe("P/L and Sharpe calculation contract", () => {
           strategy: "Grouped OO",
           legs: "call spread",
           pl: groupPl * 0.6,
-          plBasis: "net_includes_fees",
+          plBasis: PlBasis.NetIncludesFees,
           openingCommissionsFees: 1.78,
           closingCommissionsFees: 0.78,
         }),
@@ -151,7 +152,7 @@ describe("P/L and Sharpe calculation contract", () => {
           strategy: "Grouped OO",
           legs: "put spread",
           pl: groupPl * 0.4,
-          plBasis: "net_includes_fees",
+          plBasis: PlBasis.NetIncludesFees,
           openingCommissionsFees: 1.78,
           closingCommissionsFees: 0.78,
         }),
@@ -176,18 +177,18 @@ describe("P/L and Sharpe calculation contract", () => {
 
   it("uses sample N-1 volatility and echoes a fixed annual RFR", () => {
     const trades = [
-      trade({ pl: 1000, plBasis: "net_includes_fees" }),
+      trade({ pl: 1000, plBasis: PlBasis.NetIncludesFees }),
       trade({
         dateOpened: new Date("2026-01-05"),
         dateClosed: new Date("2026-01-05"),
         pl: -505,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
       trade({
         dateOpened: new Date("2026-01-06"),
         dateClosed: new Date("2026-01-06"),
         pl: 1004.95,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
     ];
     const dailyLogs: DailyLogEntry[] = [
@@ -294,7 +295,7 @@ describe("P/L and Sharpe calculation contract", () => {
         dateClosed: new Date(date),
         pl: dailyLogs[index].dailyPl,
         fundsAtClose: dailyLogs[index].netLiquidity,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
     );
 
@@ -310,12 +311,12 @@ describe("P/L and Sharpe calculation contract", () => {
 
   it("inserts zero-P/L weekdays for trade-only annualization", () => {
     const trades = [
-      trade({ dateClosed: new Date("2026-01-05"), plBasis: "net_includes_fees" }),
+      trade({ dateClosed: new Date("2026-01-05"), plBasis: PlBasis.NetIncludesFees }),
       trade({
         dateOpened: new Date("2026-01-16"),
         dateClosed: new Date("2026-01-16"),
         pl: -50,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
     ];
 
@@ -332,12 +333,12 @@ describe("P/L and Sharpe calculation contract", () => {
 
   it("discloses rolling windows as realized-trade dates rather than days", () => {
     const trades = [
-      trade({ dateClosed: new Date("2026-01-05"), plBasis: "net_includes_fees" }),
+      trade({ dateClosed: new Date("2026-01-05"), plBasis: PlBasis.NetIncludesFees }),
       trade({
         dateOpened: new Date("2026-01-16"),
         dateClosed: new Date("2026-01-16"),
         pl: -50,
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
     ];
 
@@ -353,11 +354,11 @@ describe("P/L and Sharpe calculation contract", () => {
 
   it("discloses stale historical DTB3 observations", () => {
     const trades = [
-      trade({ dateClosed: new Date("2099-01-05"), plBasis: "net_includes_fees" }),
+      trade({ dateClosed: new Date("2099-01-05"), plBasis: PlBasis.NetIncludesFees }),
       trade({
         dateOpened: new Date("2099-01-06"),
         dateClosed: new Date("2099-01-06"),
-        plBasis: "net_includes_fees",
+        plBasis: PlBasis.NetIncludesFees,
       }),
     ];
 

--- a/tests/unit/period-segmentation.test.ts
+++ b/tests/unit/period-segmentation.test.ts
@@ -322,8 +322,8 @@ describe("segmentByPeriod", () => {
 
     // 10/15 win rate
     expect(month.winRate).toBeCloseTo(10 / 15, 4);
-    // Profit factor: (10 * 200) / (5 * 150) = 2000 / 750
-    expect(month.profitFactor).toBeCloseTo(2000 / 750, 2);
+    // Profit factor uses net-after-fee P/L for both wins and losses.
+    expect(month.profitFactor).toBeCloseTo(2.5454545454545454, 2);
     // Kelly should be > 0 (more wins than implied by payoff ratio)
     expect(month.kellyPercent).toBeGreaterThan(0);
     // Net P&L: (10*200 - 5*150) - (15 * 4 commissions) = 1250 - 60

--- a/tests/unit/portfolio-stats.test.ts
+++ b/tests/unit/portfolio-stats.test.ts
@@ -239,10 +239,10 @@ describe("PortfolioStatsCalculator", () => {
       expect(stats.totalTrades).toBe(5);
       expect(stats.totalPl).toBe(900); // 500 - 100 + 200 + 400 - 100
       expect(stats.winRate).toBeCloseTo(0.6); // 3 wins out of 5
-      expect(stats.avgWin).toBeCloseTo(366.67, 1); // (500 + 200 + 400) / 3
-      expect(stats.avgLoss).toBeCloseTo(-100); // (-100 + -100) / 2
-      expect(stats.maxWin).toBe(500);
-      expect(stats.maxLoss).toBe(-100);
+      expect(stats.avgWin).toBeCloseTo(346.67, 1); // Net of declared commission fields
+      expect(stats.avgLoss).toBeCloseTo(-124);
+      expect(stats.maxWin).toBe(480);
+      expect(stats.maxLoss).toBe(-130);
     });
 
     it("should calculate drawdown metrics correctly", () => {
@@ -254,7 +254,7 @@ describe("PortfolioStatsCalculator", () => {
 
     it("should calculate initial capital correctly", () => {
       const initialCapital = PortfolioStatsCalculator.calculateInitialCapital(mockTrades);
-      expect(initialCapital).toBe(100000); // 100500 - 500
+      expect(initialCapital).toBe(100000); // Legacy provenance-free funds use reported P/L
     });
   });
 
@@ -409,7 +409,7 @@ describe("PortfolioStatsCalculator", () => {
       expect(stats.totalTrades).toBe(2);
       expect(stats.totalPl).toBe(700); // 500 + 200
       expect(stats.winRate).toBe(1.0); // Both trades were winners
-      expect(stats.avgWin).toBeCloseTo(350); // (500 + 200) / 2
+      expect(stats.avgWin).toBeCloseTo(332); // Net of declared commission fields
       expect(stats.avgLoss).toBe(0); // No losses
     });
 

--- a/tests/unit/walk-forward-analyzer.test.ts
+++ b/tests/unit/walk-forward-analyzer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { WalkForwardAnalyzer, WalkForwardConfig, Trade } from "@tradeblocks/lib";
+import { PlBasis, WalkForwardAnalyzer, WalkForwardConfig, Trade } from "@tradeblocks/lib";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -50,7 +50,7 @@ describe("WalkForwardAnalyzer", () => {
     const analyzer = new WalkForwardAnalyzer();
     const grossTrade = {
       ...createTestTrades([110], "2026-01-02", 1, 990)[0],
-      plBasis: "gross_before_fees" as const,
+      plBasis: PlBasis.GrossBeforeFees,
       openingCommissionsFees: 5,
       closingCommissionsFees: 5,
       fundsAtClose: 1100,

--- a/tests/unit/walk-forward-analyzer.test.ts
+++ b/tests/unit/walk-forward-analyzer.test.ts
@@ -46,6 +46,37 @@ function createTestTrades(
 }
 
 describe("WalkForwardAnalyzer", () => {
+  it("builds gross-basis scenario equity from scaled net P/L", () => {
+    const analyzer = new WalkForwardAnalyzer();
+    const grossTrade = {
+      ...createTestTrades([110], "2026-01-02", 1, 990)[0],
+      plBasis: "gross_before_fees" as const,
+      openingCommissionsFees: 5,
+      closingCommissionsFees: 5,
+      fundsAtClose: 1100,
+    };
+    const scenarioBuilder = (
+      analyzer as unknown as {
+        applyScenario: (
+          trades: Trade[],
+          params: Record<string, number>,
+          baseline: { baseKellyFraction: number; avgContracts: number },
+          initialCapitalOverride?: number,
+        ) => Trade[];
+      }
+    ).applyScenario.bind(analyzer);
+
+    const [scaled] = scenarioBuilder(
+      [grossTrade],
+      { fixedFractionPct: 2 },
+      { baseKellyFraction: 0, avgContracts: 1 },
+      1000,
+    );
+
+    expect(scaled.pl).toBe(110);
+    expect(scaled.fundsAtClose).toBe(1100);
+  });
+
   it("segments trades and optimizes parameters across rolling windows", async () => {
     const trades = createTestTrades(
       [500, -250, 650, -100, 300, -400, 700, 200, -150, 450, -200, 550],


### PR DESCRIPTION
Tier: 2
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-1331-metric-contract

## Summary

- make reported, gross, and net P/L explicit so Option Omega exports are not charged fees twice, including grouped-leg, subset, walk-forward, Monte Carlo, counterfactual, chart, and DuckDB paths
- export a runtime `PlBasis` enum and use it in the Trade type, Zod schemas, import API, loaders, calculations, grouping, and sync paths while preserving the exact CSV/DuckDB wire values
- reject explicitly gross imports and sync rows unless both fee fields contain finite values
- add optional `riskFreeRateAnnualPct` support to statistics and rolling Sharpe/Sortino calculations while keeping historical DTB3 as the default and returning the applied methodology
- standardize realized-performance filtering and stress-scenario bounds on close date (falling back to open date), including local-calendar handling across timezones
- return MCP `structuredContent`, preserve source-reported P/L beside canonical net P/L in DuckDB, and accept both Option Omega fee-header aliases plus formatted numeric values

## Root cause

The trade shape did not declare whether exported P/L already included commissions. Parallel metric surfaces therefore inferred different fee and date semantics, while Sharpe/Sortino did not expose enough risk-free-rate provenance to explain comparisons with Option Omega.

## Impact

Option Omega net P/L now stays net throughout analysis, grouped legs preserve totals and fees, metric subsets and what-if scenarios use their own net equity curves, and callers can reproduce a fixed annual RFR explicitly. The supplied runs reproduce Option Omega at $10,704.08 / Sharpe 1.20 / Sortino 2.34 and, for the grouped-leg run, $9,340.40 / Sharpe 0.88 / Sortino 1.68 using a 2.5% fixed annual RFR.

No supplied private logs or screenshots are committed; parity is covered with reduced synthetic fixtures. The pending 3.7.0 release note calls out the Sharpe re-baseline and P/L basis requirements.

## Validation

- Core Jest: 80 suites, 1,353 tests passed
- MCP Jest: 139 suites, 1,804 tests passed (`--max-old-space-size=8192`)
- TypeScript, ESLint, Prettier, `git diff --check`: passed
- Root Next.js production build: passed
- MCP production build: passed
- Independent Worf Tier-2 and substantive gate: PASS, including timezone and runtime-enum hostile probes

Companion Enterprise adapter/reconciliation fix: tradeblocks-org/enterprise#1988. Preferred merge order: this PR first, then enterprise#1988; either transitional order is runtime-safe, but full correctness requires both.

Closes tradeblocks-org/enterprise#1331
