### PR TITLE
Release tradeblocks-mcp 3.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,24 @@ jobs:
         run: |
           ROOT=$(node -p "require('./package.json').version")
           PKG=$(node -p "require('./packages/mcp-server/package.json').version")
-          if [ "$ROOT" != "$PKG" ]; then
-            echo "::error::Version divergence: root package.json ($ROOT) != packages/mcp-server/package.json ($PKG). This pipeline publishes off the mcp-server version, so a mismatch silently skips the npm publish (the release no-ops green and nothing ships). Bump both in lockstep before merging."
+          ROOT_LOCK=$(node -p "require('./package-lock.json').packages[''].version")
+          PKG_LOCK=$(node -p "require('./package-lock.json').packages['packages/mcp-server'].version")
+          if [ "$ROOT" != "$PKG" ] || [ "$ROOT" != "$ROOT_LOCK" ] || [ "$ROOT" != "$PKG_LOCK" ]; then
+            echo "::error::Version divergence: root=$ROOT, mcp=$PKG, root-lock=$ROOT_LOCK, mcp-lock=$PKG_LOCK. This pipeline publishes off the mcp-server version, so all four values must move in lockstep."
             exit 1
           fi
-          echo "Versions in sync: $ROOT"
+          echo "Manifest and lockfile versions in sync: $ROOT"
+
+      - name: Verify release notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          NOTES="releases/v${VERSION}.md"
+          if [ ! -s "$NOTES" ]; then
+            echo "::error::Missing or empty release notes: $NOTES"
+            exit 1
+          fi
+          echo "Release notes found: $NOTES"
 
   publish-npm:
     name: Publish to npm
@@ -179,28 +192,4 @@ jobs:
           tag_name: v${{ needs.build.outputs.version }}
           name: v${{ needs.build.outputs.version }}
           generate_release_notes: true
-          body: |
-            ## Installation
-
-            ### npm (recommended)
-            ```bash
-            npx tradeblocks-mcp ~/path/to/backtests
-            ```
-
-            For Claude Desktop, add the server to `claude_desktop_config.json` with `command: npx`, `args: ["tradeblocks-mcp", "~/path/to/backtests"]`.
-
-            ### Docker
-            ```bash
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/tradeblocks-mcp:${{ needs.build.outputs.version }}
-            docker run -p 3100:3100 -v ./data:/data --env-file .env ${{ secrets.DOCKERHUB_USERNAME }}/tradeblocks-mcp:${{ needs.build.outputs.version }}
-            ```
-
-            ### From Source
-            ```bash
-            git clone https://github.com/tradeblocks-org/tradeblocks
-            cd tradeblocks && npm install && npm run build:mcp
-            ```
-
-            ---
-
-            Note: the canonical repo is now `tradeblocks-org/tradeblocks`. GitHub redirects keep old `davidromeo/tradeblocks` URLs working.
+          body_path: releases/v${{ needs.build.outputs.version }}.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -22897,7 +22897,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.4",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/releases/v3.7.0.md
+++ b/releases/v3.7.0.md
@@ -49,3 +49,31 @@ floor, and the grow-only cumulative raw search count.
 The centroid interval refuses instead of interpolating when the requested
 two-sided confidence endpoints are unattainable at the supplied finite
 resample count. For example, a 95% interval requires at least 39 resamples.
+
+## Installation
+
+### npm (recommended)
+
+```bash
+npx tradeblocks-mcp ~/path/to/backtests
+```
+
+For Claude Desktop, add the server to `claude_desktop_config.json` with
+`command: npx`, `args: ["tradeblocks-mcp", "~/path/to/backtests"]`.
+
+### Docker
+
+```bash
+docker pull ghcr.io/tradeblocks-org/tradeblocks-mcp:3.7.0
+docker run -p 3100:3100 -v ./data:/data --env-file .env ghcr.io/tradeblocks-org/tradeblocks-mcp:3.7.0
+```
+
+### From source
+
+```bash
+git clone https://github.com/tradeblocks-org/tradeblocks
+cd tradeblocks && npm install && npm run build:mcp
+```
+
+The canonical repository is `tradeblocks-org/tradeblocks`. GitHub redirects
+keep old `davidromeo/tradeblocks` URLs working.


### PR DESCRIPTION
Tier: 2
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-1331-metric-contract

## Summary

- bump the publishable `tradeblocks-mcp` package and workspace lock entry from 3.6.1 to 3.7.0
- require root, MCP, and both lockfile versions to agree before any publishing job can run
- require a non-empty `releases/v<version>.md` before publication
- use the versioned release note as the curated GitHub release preamble while retaining generated notes
- preserve the stable installation instructions in the canonical 3.7.0 release note

## Root cause

PR #402 merged with the private root manifest already at 3.7.0 while the publishable MCP package remained at 3.6.1. The release workflow correctly stopped before publication, but the versioned release note was not wired into the GitHub release body.

## Impact

Merging this PR makes `tradeblocks-mcp@3.7.0` publishable and makes `releases/v3.7.0.md` authoritative for the curated release text. Version or release-note drift fails in the build job before npm, Docker, or GitHub release mutations.

## Validation

- confirmed the failed #402 release run stopped at version divergence before publication
- `npm ci --ignore-scripts`: passed
- four-way manifest/lockfile version guard: passed at 3.7.0
- positive and negative release-note guards: passed
- release workflow YAML parse and Prettier: passed
- ESLint and `git diff --check`: passed
- packed-provenance runtime verification: passed
- `npm pack --dry-run`: `tradeblocks-mcp@3.7.0`
- `npm publish --dry-run --workspace=tradeblocks-mcp --access public --provenance`: passed
- npm registry check: 3.7.0 is available

Follow-up to #402.
