### PR TITLE
Fail loud on empty trading-day spot refreshes

### DIFF
--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -25,6 +25,11 @@ import {
   type QuoteGreeksStats,
 } from "../../utils/option-quote-greeks.ts";
 import { runCanonicalProvenanceRefresh } from "../provenance/refresh-completion.ts";
+import {
+  XNYS_SESSION_CALENDAR_SUPPORTED_FROM,
+  XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH,
+  isXnysSessionDate,
+} from "../provenance/xnys-session-calendar.ts";
 
 export interface MarketIngestorDeps {
   stores: MarketStores;
@@ -124,24 +129,18 @@ function providerErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/**
- * Identify dates the US options market is closed. Currently weekends only —
- * holiday list is intentional TODO. ThetaData (and likely other providers)
- * return junk data on weekends (zero-priced "quotes" for every contract on
- * Sundays in particular), so refresh() short-circuits these dates.
- *
- * Lower-level methods (ingestBars/ingestChain/ingestQuotes) are unchanged —
- * callers needing forensic per-weekend fetches can call them directly.
- */
+/** Identify dates known to be full-day XNYS closures. */
 function isNonTradingDay(asOf: string): boolean {
-  // asOf is YYYY-MM-DD. Use UTC noon to avoid TZ drift across the date
-  // boundary on hosts in negative-offset timezones.
   const d = new Date(`${asOf}T12:00:00Z`);
   const dow = d.getUTCDay();
   if (dow === 0 || dow === 6) return true;
-  // TODO: NYSE holiday calendar (MLK, Presidents, Good Friday, Memorial,
-  // Juneteenth, Independence, Labor, Thanksgiving, Christmas, New Year).
-  return false;
+  if (
+    asOf < XNYS_SESSION_CALENDAR_SUPPORTED_FROM ||
+    asOf > XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH
+  ) {
+    return false;
+  }
+  return !isXnysSessionDate(asOf);
 }
 
 function unsupportedProviderResult(
@@ -415,6 +414,52 @@ export class MarketIngestor {
     } catch {
       return result;
     }
+  }
+
+  private async enforceSpotRefreshCompleteness(
+    symbol: string,
+    asOf: string,
+    result: IngestResult,
+  ): Promise<IngestResult> {
+    if (result.rowsWritten > 0 || result.status !== "ok") return result;
+
+    try {
+      const coverage = await this.deps.stores.spot.getCoverage(symbol.toUpperCase(), asOf, asOf);
+      if (coverage.totalDates > 0) {
+        return {
+          status: "skipped",
+          rowsWritten: 0,
+          dateRange: { from: asOf, to: asOf },
+          details: {
+            ...(result.details ?? {}),
+            reason: "using_cached_coverage",
+            dataset: "spot",
+            symbol: symbol.toUpperCase(),
+            originalStatus: result.status,
+            cachedCoverage: {
+              totalDates: coverage.totalDates,
+              earliest: coverage.earliest,
+              latest: coverage.latest,
+            },
+          },
+        };
+      }
+    } catch {
+      // A failed coverage read cannot prove that the requested partition exists.
+    }
+
+    return {
+      status: "error",
+      rowsWritten: 0,
+      error: `Spot refresh for ${symbol.toUpperCase()} on ${asOf} returned zero rows and exact-date coverage remains absent`,
+      details: {
+        ...(result.details ?? {}),
+        reason: "zero_rows",
+        dataset: "spot",
+        symbol: symbol.toUpperCase(),
+        asOf,
+      },
+    };
   }
 
   private quoteGreeksSourceForProvider(
@@ -1269,7 +1314,8 @@ export class MarketIngestor {
         timespan: "1m",
         provider: opts.provider,
       });
-      const result = await this.applyCoverageFallback("spot", ticker, opts.asOf, rawResult);
+      const fallbackResult = await this.applyCoverageFallback("spot", ticker, opts.asOf, rawResult);
+      const result = await this.enforceSpotRefreshCompleteness(ticker, opts.asOf, fallbackResult);
       spotResults.push(result);
       if (result.status === "error") errors.push(`spot ${ticker}: ${result.error}`);
     }

--- a/packages/mcp-server/tests/unit/market/ingestor/ingest-bars.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/ingest-bars.test.ts
@@ -116,6 +116,25 @@ describe("MarketIngestor.ingestBars", () => {
     expect(result.rowsWritten).toBe(4);
   });
 
+  it("preserves zero-row forensic ingest results below the refresh boundary", async () => {
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false });
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => makeFakeProvider([]),
+    });
+
+    const result = await ingestor.ingestBars({
+      tickers: ["SPX"],
+      from: "2026-07-30",
+      to: "2026-07-30",
+      timespan: "1m",
+      skipEnrichment: true,
+    });
+
+    expect(result).toEqual({ status: "ok", rowsWritten: 0, enrichment: null });
+  });
+
   it("routes intraday timespan to minute bars", async () => {
     const intradayBars: BarRow[] = [
       {

--- a/packages/mcp-server/tests/unit/market/ingestor/ingest-open-interest.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/ingest-open-interest.test.ts
@@ -221,7 +221,7 @@ describe("MarketIngestor.refresh open-interest gating", () => {
     });
 
     const result = await ingestor.refresh({
-      asOf: "2024-01-15",
+      asOf: "2024-01-16",
       spotTickers: [],
     });
 
@@ -242,7 +242,7 @@ describe("MarketIngestor.refresh open-interest gating", () => {
     });
 
     const result = await ingestor.refresh({
-      asOf: "2024-01-15",
+      asOf: "2024-01-16",
       spotTickers: [],
       openInterestUnderlyings: ["SPX"],
     });

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -10,7 +10,7 @@ import { TickerRegistry } from "../../../../src/market/tickers/registry.ts";
 import type { MarketDataProvider, BarRow } from "../../../../src/utils/market-provider.ts";
 
 // ---------------------------------------------------------------------------
-// Non-trading day short-circuit (weekend skip)
+// Non-trading day short-circuit (weekend and full-day XNYS closure skip)
 // ---------------------------------------------------------------------------
 describe("MarketIngestor.refresh — weekend short-circuit", () => {
   let dataDir: string;
@@ -175,6 +175,44 @@ describe("MarketIngestor.refresh — weekend short-circuit", () => {
     expect(result.perOperation.chain).toHaveLength(0);
     expect(result.perOperation.quotes).toHaveLength(0);
     expect(result.perOperation.vixContext).toBeNull();
+    expect(result.errors).toHaveLength(0);
+    expect(fetchBarsCalled).toBe(false);
+  });
+
+  it("returns status=skipped without provider calls for an XNYS full-day closure", async () => {
+    let fetchBarsCalled = false;
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => ({
+        name: "spy",
+        capabilities: () => ({
+          tradeBars: true,
+          quotes: false,
+          greeks: false,
+          flatFiles: false,
+          bulkByRoot: false,
+          perTicker: true,
+          minuteBars: true,
+          dailyBars: true,
+        }),
+        fetchBars: async () => {
+          fetchBarsCalled = true;
+          return [];
+        },
+        fetchOptionSnapshot: async () => ({ contracts: [] }),
+      }),
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-07-03",
+      spotTickers: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(result.perOperation.spot).toHaveLength(0);
     expect(result.errors).toHaveLength(0);
     expect(fetchBarsCalled).toBe(false);
   });
@@ -350,6 +388,74 @@ describe("MarketIngestor.refresh", () => {
       expect.objectContaining({ ticker: "SPX", timespan: "minute", multiplier: 1 }),
       expect.objectContaining({ ticker: "QQQ", timespan: "minute", multiplier: 1 }),
     ]);
+  });
+
+  it("fails a trading-day spot refresh when the provider returns zero rows and coverage is absent", async () => {
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => makeBarsProvider([]),
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-07-30",
+      spotTickers: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.perOperation.spot).toEqual([
+      expect.objectContaining({
+        status: "error",
+        rowsWritten: 0,
+        error: expect.stringMatching(/SPX.*2026-07-30.*zero rows.*coverage remains absent/i),
+        details: expect.objectContaining({ reason: "zero_rows", symbol: "SPX" }),
+      }),
+    ]);
+    expect(result.errors).toEqual([
+      expect.stringMatching(/spot SPX:.*SPX.*2026-07-30.*zero rows/i),
+    ]);
+  });
+
+  it("accepts zero newly written rows when exact-date spot coverage already exists", async () => {
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    await stores.spot.writeBars("SPX", "2026-07-30", [
+      {
+        ticker: "SPX",
+        date: "2026-07-30",
+        time: "09:30",
+        open: 6400,
+        high: 6405,
+        low: 6395,
+        close: 6401,
+        volume: 0,
+      },
+    ]);
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => makeBarsProvider([]),
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-07-30",
+      spotTickers: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.perOperation.spot).toEqual([
+      expect.objectContaining({
+        status: "skipped",
+        rowsWritten: 0,
+        details: expect.objectContaining({
+          reason: "using_cached_coverage",
+          symbol: "SPX",
+        }),
+      }),
+    ]);
+    expect(result.errors).toHaveLength(0);
   });
 
   it("runs ingestBars per spot ticker and reports per-operation results", async () => {


### PR DESCRIPTION
Tier: 2
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-2355-zero-row-refresh

## Summary
- reuse the bounded producer-owned XNYS calendar for ordinary refresh closure detection
- reject a requested trading-day spot refresh that writes zero rows unless exact-date cached coverage already exists
- preserve lower-level `ingestBars()` zero-row behavior for forensic callers
- move stale open-interest fixtures from MLK Day to a real session

## Verification
- `npm test -- --runInBand tests/unit/market/ingestor` (7 suites, 56 tests)
- `npm exec tsc -- --noEmit -p packages/mcp-server/tsconfig.json`
- ESLint on changed TypeScript files
- `git diff --check`

Worf: CLEAR on `e3708c1b808ba67f7855eeb9111a886e8d9d84ec` (Tier 2).

Delivery order: land this producer change before the paired Holodeck consumer PR.

Refs tradeblocks-org/enterprise#2355.