### PR TITLE
Exit analysis decides on exact P&L, not just exact thresholds

### DIFF
--- a/packages/mcp-server/src/tools/batch-exit-analysis.ts
+++ b/packages/mcp-server/src/tools/batch-exit-analysis.ts
@@ -304,7 +304,9 @@ export async function handleBatchExitAnalysis(
           injectedConn,
         );
 
-        // Compute entry cost for percentage-based triggers (D-11)
+        // Binary accumulation is deliberate: tradeEntryCost enters the money domain
+        // before any percentage threshold is derived. Its snap was measured to remove
+        // the order-dependent accumulation noise across the tool's realistic range.
         const tradeEntryCost = replayResult.legs.reduce((sum: number, leg) => {
           return sum + leg.entryPrice * leg.quantity * leg.multiplier;
         }, 0);

--- a/packages/mcp-server/src/tools/batch-exit-analysis.ts
+++ b/packages/mcp-server/src/tools/batch-exit-analysis.ts
@@ -25,6 +25,7 @@ import {
 import { getProfile } from "../db/profile-schemas.ts";
 import type { ExitTriggerConfig, LegGroupConfig } from "../utils/exit-triggers.ts";
 import type { MarketStores } from "../market/stores/index.ts";
+import { addMoney, fromMoney, toMoneyField, type Money } from "../utils/money.ts";
 
 // ---------------------------------------------------------------------------
 // Concurrency limiter — hand-rolled semaphore, no external dependency (D-15)
@@ -304,12 +305,15 @@ export async function handleBatchExitAnalysis(
           injectedConn,
         );
 
-        // Binary accumulation is deliberate: tradeEntryCost enters the money domain
-        // before any percentage threshold is derived. Its snap was measured to remove
-        // the order-dependent accumulation noise across the tool's realistic range.
-        const tradeEntryCost = replayResult.legs.reduce((sum: number, leg) => {
-          return sum + leg.entryPrice * leg.quantity * leg.multiplier;
-        }, 0);
+        let tradeEntryCostMoney: Money = 0;
+        for (const leg of replayResult.legs) {
+          tradeEntryCostMoney = addMoney(
+            tradeEntryCostMoney,
+            toMoneyField(leg.entryPrice * leg.quantity * leg.multiplier, "leg entry cost"),
+            "entry cost",
+          );
+        }
+        const tradeEntryCost = fromMoney(tradeEntryCostMoney);
 
         return {
           ok: true,

--- a/packages/mcp-server/src/tools/exit-analysis.ts
+++ b/packages/mcp-server/src/tools/exit-analysis.ts
@@ -279,7 +279,9 @@ export async function handleAnalyzeExitTriggers(
   const pnlPath = replayResult.pnlPath;
   const replayLegs = replayResult.legs;
 
-  // Compute entry cost for percentage-based triggers
+  // Binary accumulation is deliberate: entryCost enters the money domain before
+  // any percentage threshold is derived. Its snap was measured to remove the
+  // order-dependent accumulation noise across the tool's realistic range.
   const entryCost = replayLegs.reduce((sum, leg) => {
     return sum + leg.entryPrice * leg.quantity * leg.multiplier;
   }, 0);

--- a/packages/mcp-server/src/tools/exit-analysis.ts
+++ b/packages/mcp-server/src/tools/exit-analysis.ts
@@ -22,6 +22,7 @@ import {
 } from "../utils/exit-triggers.ts";
 import { decomposeGreeks, type LegGroupDef } from "../utils/greeks-decomposition.ts";
 import { markPrice } from "../utils/trade-replay.ts";
+import { addMoney, fromMoney, toMoneyField, type Money } from "../utils/money.ts";
 
 // ---------------------------------------------------------------------------
 // Shared trigger type enum
@@ -279,12 +280,15 @@ export async function handleAnalyzeExitTriggers(
   const pnlPath = replayResult.pnlPath;
   const replayLegs = replayResult.legs;
 
-  // Binary accumulation is deliberate: entryCost enters the money domain before
-  // any percentage threshold is derived. Its snap was measured to remove the
-  // order-dependent accumulation noise across the tool's realistic range.
-  const entryCost = replayLegs.reduce((sum, leg) => {
-    return sum + leg.entryPrice * leg.quantity * leg.multiplier;
-  }, 0);
+  let entryCostMoney: Money = 0;
+  for (const leg of replayLegs) {
+    entryCostMoney = addMoney(
+      entryCostMoney,
+      toMoneyField(leg.entryPrice * leg.quantity * leg.multiplier, "leg entry cost"),
+      "entry cost",
+    );
+  }
+  const entryCost = fromMoney(entryCostMoney);
 
   if (pnlPath.length === 0) {
     return {

--- a/packages/mcp-server/src/utils/exit-triggers.ts
+++ b/packages/mcp-server/src/utils/exit-triggers.ts
@@ -8,7 +8,16 @@
  */
 
 import type { PnlPoint, ReplayLeg } from "./trade-replay.ts";
-import { applyRatioField, formatMoney, formatPercent, fromMoney, toMoneyField } from "./money.ts";
+import {
+  addMoney,
+  applyRatioField,
+  formatMoney,
+  formatPercent,
+  fromMoney,
+  legPnlMoney,
+  toMoneyField,
+  type Money,
+} from "./money.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -367,14 +376,22 @@ export function evaluateTrigger(
       case "trailingStop": {
         const trailAmt = trigger.trailAmount ?? threshold;
         // The peak must be a real amount rather than the unarmed sentinel before
-        // the raw P&L drop can be compared with the validated trail.
+        // the exact P&L drop can be compared with the validated trail.
         const trailArmed = Number.isFinite(runningMaxPnl);
-        const dropdown = trailArmed ? runningMaxPnl - pnl : 0;
+        const dropdownMoney = trailArmed
+          ? addMoney(
+              toMoneyField(runningMaxPnl, "running maximum P&L"),
+              -toMoneyField(pnl, "P&L"),
+              "P&L dropdown",
+            )
+          : 0;
+        const trailMoney = toMoneyField(trailAmt, "trailAmount");
         // trailAmount and threshold are used as DOLLARS here whatever `unit`
         // says, so they are validated as dollars whatever `unit` says.
-        if (trailArmed && dropdown >= fromMoney(toMoneyField(trailAmt, "trailAmount"))) {
+        if (trailArmed && dropdownMoney >= trailMoney) {
+          const dropdown = fromMoney(dropdownMoney);
           fired = true;
-          detail = `Dropdown $${dropdown.toFixed(2)} from max $${runningMaxPnl.toFixed(2)} >= trail $${formatMoney(toMoneyField(trailAmt, "trailAmount"))}`;
+          detail = `Dropdown $${dropdown.toFixed(2)} from max $${runningMaxPnl.toFixed(2)} >= trail $${formatMoney(trailMoney)}`;
         }
         break;
       }
@@ -604,15 +621,19 @@ export function evaluateTrigger(
  */
 function computeGroupPnl(pnlPath: PnlPoint[], legs: ReplayLeg[], legIndices: number[]): number[] {
   return pnlPath.map((point) => {
-    let groupPnl = 0;
+    let groupPnlMoney: Money = 0;
     for (const idx of legIndices) {
       if (idx < legs.length && idx < point.legPrices.length) {
         const leg = legs[idx];
         const markPrice = point.legPrices[idx];
-        groupPnl += (markPrice - leg.entryPrice) * leg.quantity * leg.multiplier;
+        groupPnlMoney = addMoney(
+          groupPnlMoney,
+          legPnlMoney(markPrice, leg.entryPrice, leg.quantity, leg.multiplier),
+          "leg group P&L",
+        );
       }
     }
-    return groupPnl;
+    return fromMoney(groupPnlMoney);
   });
 }
 
@@ -685,10 +706,17 @@ export function analyzeExitTriggers(config: {
       closestIdx = pnlPath.length - 1;
     }
     const actualPnl = pnlPath[closestIdx].strategyPnl;
+    const pnlDifference = fromMoney(
+      addMoney(
+        toMoneyField(firstToFire.pnlAtFire, "trigger P&L"),
+        -toMoneyField(actualPnl, "actual exit P&L"),
+        "exit P&L difference",
+      ),
+    );
     actualExit = {
       timestamp: pnlPath[closestIdx].timestamp,
       pnl: actualPnl,
-      pnlDifference: firstToFire.pnlAtFire - actualPnl,
+      pnlDifference,
     };
   }
 
@@ -765,10 +793,17 @@ export function analyzeExitTriggers(config: {
           closestIdx = pnlPath.length - 1;
         }
         const actualGroupPnl = groupPnlArr[closestIdx];
+        const pnlDifference = fromMoney(
+          addMoney(
+            toMoneyField(groupFirstToFire.pnlAtFire, "group trigger P&L"),
+            -toMoneyField(actualGroupPnl, "group actual exit P&L"),
+            "group exit P&L difference",
+          ),
+        );
         groupActualExit = {
           timestamp: pnlPath[closestIdx].timestamp,
           pnl: actualGroupPnl,
-          pnlDifference: groupFirstToFire.pnlAtFire - actualGroupPnl,
+          pnlDifference,
         };
       }
 

--- a/packages/mcp-server/src/utils/money.ts
+++ b/packages/mcp-server/src/utils/money.ts
@@ -11,18 +11,15 @@
  * a stop it is being told it has reached, and the analysis answers that the stop
  * did not fire. The comparison and the reported figure were different numbers.
  *
- * SCOPE, AND WHY IT STOPS WHERE IT DOES. This module governs the monetary amounts
- * this tool converts or derives — direct thresholds and trails, percentage
- * thresholds from an entry cost, and a step's arm and stop. It deliberately does
- * not touch the P&L path, which arrives already computed from the replay. Making
- * claims about the intended decimal value of a number this tool did not compute
- * means inventing a rounding policy for values with no ground truth, and every
- * such rule has an edge: promoting a sub-micro P&L to keep its sign flips its
- * decision against a one-micro threshold, while rounding it to zero flips its
- * decision against a zero threshold. Neither is correct, because the question is
- * unanswerable from here. So the tool derives its own fixed-point thresholds
- * exactly, compares the P&L it was handed against them as given, and claims
- * nothing further.
+ * SCOPE. This module governs the monetary amounts the exit-analysis tool computes:
+ * direct thresholds and trails, percentage thresholds from an entry cost, a
+ * step's arm and stop, and replayed P&L. Each replay leg enters the domain before
+ * its price difference is taken, then leg values are resolved and added in the
+ * domain. Integral position scaling stays integer throughout; fractional scaling
+ * accepted by the public replay interface resolves back into the domain per leg.
+ * A P&L leaves the domain only once, after the position or leg group has been
+ * accumulated. Differences used for exit decisions and comparisons are also
+ * taken in the domain.
  *
  * REPRESENTATION. A fixed-point integer count of micro-dollars (1e-6 USD) held in
  * an ordinary number. Integers below 2^53 are exact, covering roughly
@@ -74,6 +71,41 @@ export function toMoneyField(amount: number, field: string): Money {
     );
   }
   return scaled === 0 ? 0 : scaled;
+}
+
+function checkedMoney(value: number, field: string): Money {
+  if (!Number.isSafeInteger(value)) {
+    throw new MoneyDomainError(`${field} is beyond the exact monetary range`);
+  }
+  return value === 0 ? 0 : value;
+}
+
+/** Add two monetary values without leaving the fixed-point domain. */
+export function addMoney(left: Money, right: Money, field: string): Money {
+  return checkedMoney(left + right, field);
+}
+
+/** Compute one replay leg's P&L with the price difference taken in the domain. */
+export function legPnlMoney(
+  markPrice: number,
+  entryPrice: number,
+  quantity: number,
+  multiplier: number,
+): Money {
+  const priceDifference = addMoney(
+    toMoneyField(markPrice, "mark price"),
+    -toMoneyField(entryPrice, "entry price"),
+    "price difference",
+  );
+  const scaled = priceDifference * quantity * multiplier;
+  if (!Number.isFinite(scaled)) {
+    throw new MoneyDomainError("leg P&L must be a finite dollar amount");
+  }
+  return Number.isSafeInteger(scaled)
+    ? scaled === 0
+      ? 0
+      : scaled
+    : toMoneyField(fromMoney(priceDifference) * quantity * multiplier, "leg P&L");
 }
 
 /**

--- a/packages/mcp-server/src/utils/money.ts
+++ b/packages/mcp-server/src/utils/money.ts
@@ -101,6 +101,8 @@ export function legPnlMoney(
   if (!Number.isFinite(scaled)) {
     throw new MoneyDomainError("leg P&L must be a finite dollar amount");
   }
+  // Fractional scaling resolves each leg independently to the micro-dollar grid;
+  // callers then add those integers, so the result remains independent of leg order.
   return Number.isSafeInteger(scaled)
     ? scaled === 0
       ? 0

--- a/packages/mcp-server/src/utils/trade-replay.ts
+++ b/packages/mcp-server/src/utils/trade-replay.ts
@@ -9,6 +9,7 @@
 
 import type { BarRow } from "./market-provider.ts";
 import { computeLegGreeks, type GreeksResult } from "./black-scholes.ts";
+import { addMoney, fromMoney, legPnlMoney, type Money } from "./money.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -391,7 +392,7 @@ export function computeStrategyPnlPath(
   for (const ts of sortedTimestamps) {
     let complete = true;
     const legPrices: number[] = [];
-    let strategyPnl = 0;
+    let strategyPnlMoney: Money = 0;
 
     for (let i = 0; i < legs.length; i++) {
       const bar = legMaps[i].get(ts);
@@ -405,10 +406,15 @@ export function computeStrategyPnlPath(
       }
       const hl2 = markPrice(effective);
       legPrices.push(hl2);
-      strategyPnl += (hl2 - legs[i].entryPrice) * legs[i].quantity * legs[i].multiplier;
+      strategyPnlMoney = addMoney(
+        strategyPnlMoney,
+        legPnlMoney(hl2, legs[i].entryPrice, legs[i].quantity, legs[i].multiplier),
+        "strategy P&L",
+      );
     }
 
     if (complete) {
+      const strategyPnl = fromMoney(strategyPnlMoney);
       const point: PnlPoint = { timestamp: ts, strategyPnl, legPrices };
 
       // Compute greeks if config provided

--- a/packages/mcp-server/tests/unit/exit-analysis-tool-money-boundary.test.ts
+++ b/packages/mcp-server/tests/unit/exit-analysis-tool-money-boundary.test.ts
@@ -72,6 +72,8 @@ const BASE_LEG = {
   expiry: "2026-01-05",
 };
 
+const OUT_OF_DOMAIN_ENTRY_PRICE = 9_007_199_255;
+
 function pnlPath(values: number[]) {
   return values.map((strategyPnl, index) => ({
     timestamp: `2026-01-05 09:${String(30 + index).padStart(2, "0")}`,
@@ -255,6 +257,24 @@ describe("registered analyze_exit_triggers money boundaries", () => {
     expect(data.overall.firstToFire!.pnlAtFire).toBe(resolvedTarget);
     expect(data.overall.firstToFire!.detail).toContain("target $281474976.710656");
   });
+
+  it("returns an explicit error for an out-of-domain entry cost", async () => {
+    const result = await runAnalyzeTool(
+      {
+        legs: [{ ...BASE_LEG, quantity: 1, entry_price: OUT_OF_DOMAIN_ENTRY_PRICE }],
+        multiplier: 1,
+        triggers: [{ type: "profitTarget", unit: "dollar", threshold: 1 }],
+      },
+      [0],
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0]?.text).toContain("Error analyzing exit triggers");
+    expect(result.content[0]?.text).toContain(
+      "leg entry cost is beyond the largest dollar amount this analysis can represent",
+    );
+  });
 });
 
 describe("registered batch_exit_analysis money boundaries", () => {
@@ -286,5 +306,70 @@ describe("registered batch_exit_analysis money boundaries", () => {
     }
 
     expect(results).toEqual(["noTrigger", "noTrigger"]);
+  });
+
+  it("skips an out-of-domain entry cost while completing the rest of the batch", async () => {
+    runAndReadAll.mockResolvedValueOnce({
+      getRows: () => [
+        [0, 10, "2026-01-05"],
+        [1, 20, "2026-01-06"],
+      ],
+    });
+    handleReplayTrade
+      .mockResolvedValueOnce({
+        pnlPath: pnlPath([0]),
+        legs: [
+          {
+            occTicker: BASE_LEG.ticker,
+            quantity: 1,
+            entryPrice: OUT_OF_DOMAIN_ENTRY_PRICE,
+            multiplier: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        pnlPath: pnlPath([0, 1]),
+        legs: [
+          {
+            occTicker: BASE_LEG.ticker,
+            quantity: 1,
+            entryPrice: 1,
+            multiplier: 1,
+          },
+        ],
+      });
+
+    const result = await batchHandler(
+      batchSchema.parse({
+        block_id: "out-of-domain-entry-cost",
+        candidate_policy: [{ type: "profitTarget", unit: "dollar", threshold: 1 }],
+        baseline_mode: "actual",
+        limit: 2,
+        multiplier: 1,
+        format: "full",
+      }),
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toBeDefined();
+    const data = result.structuredContent as {
+      summary: string;
+      perTrade: Array<{ tradeIndex: number; triggerFired: string; candidatePnl: number }>;
+      skippedTrades: Array<{ tradeIndex: number; dateOpened: string; error: string }>;
+    };
+    expect(data.summary).toContain("Analyzed 1 trades (1 skipped due to replay errors)");
+    expect(data.perTrade).toHaveLength(1);
+    expect(data.perTrade[0]?.tradeIndex).toBe(1);
+    expect(data.perTrade[0]?.triggerFired).toBe("noTrigger");
+    expect(data.perTrade[0]?.candidatePnl).toBe(1);
+    expect(data.skippedTrades).toEqual([
+      {
+        tradeIndex: 0,
+        dateOpened: "2026-01-05",
+        error: expect.stringContaining(
+          "leg entry cost is beyond the largest dollar amount this analysis can represent",
+        ),
+      },
+    ]);
   });
 });

--- a/packages/mcp-server/tests/unit/exit-analysis-tool-money-boundary.test.ts
+++ b/packages/mcp-server/tests/unit/exit-analysis-tool-money-boundary.test.ts
@@ -2,12 +2,28 @@ import { jest } from "@jest/globals";
 import type { z } from "zod";
 
 const handleReplayTrade = jest.fn();
+const runAndReadAll = jest.fn(async () => ({
+  getRows: () => [[0, 0, "2026-01-05"]],
+}));
+const getConnection = jest.fn(async () => ({ runAndReadAll }));
 
 jest.unstable_mockModule("../../src/tools/replay.ts", () => ({
   handleReplayTrade,
 }));
 
-const { registerExitAnalysisTools } = await import("../../src/tools/exit-analysis.ts");
+jest.unstable_mockModule("../../src/db/connection.ts", () => ({
+  getConnection,
+}));
+
+const [
+  { registerExitAnalysisTools },
+  { registerBatchExitAnalysisTools },
+  { computeStrategyPnlPath },
+] = await Promise.all([
+  import("../../src/tools/exit-analysis.ts"),
+  import("../../src/tools/batch-exit-analysis.ts"),
+  import("../../src/utils/trade-replay.ts"),
+]);
 
 type ToolResult = {
   structuredContent?: Record<string, unknown>;
@@ -21,7 +37,10 @@ interface ToolConfig {
   inputSchema: z.ZodType<Record<string, unknown>>;
 }
 
-function captureAnalyzeTool(): { schema: ToolConfig["inputSchema"]; handler: ToolHandler } {
+function captureTool(name: "analyze_exit_triggers" | "batch_exit_analysis"): {
+  schema: ToolConfig["inputSchema"];
+  handler: ToolHandler;
+} {
   const tools = new Map<string, { config: ToolConfig; handler: ToolHandler }>();
   const server = {
     registerTool(name: string, config: ToolConfig, handler: ToolHandler) {
@@ -30,15 +49,21 @@ function captureAnalyzeTool(): { schema: ToolConfig["inputSchema"]; handler: Too
   };
 
   const stores = {};
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  registerExitAnalysisTools(server as any, "/unused", stores as any);
+  const registeredServer = server as unknown as Parameters<typeof registerExitAnalysisTools>[0];
+  const marketStores = stores as unknown as Parameters<typeof registerExitAnalysisTools>[2];
+  if (name === "analyze_exit_triggers") {
+    registerExitAnalysisTools(registeredServer, "/unused", marketStores);
+  } else {
+    registerBatchExitAnalysisTools(registeredServer, "/unused", marketStores);
+  }
 
-  const tool = tools.get("analyze_exit_triggers");
-  if (!tool) throw new Error("analyze_exit_triggers was not registered");
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`${name} was not registered`);
   return { schema: tool.config.inputSchema, handler: tool.handler };
 }
 
-const { schema, handler } = captureAnalyzeTool();
+const { schema, handler } = captureTool("analyze_exit_triggers");
+const { schema: batchSchema, handler: batchHandler } = captureTool("batch_exit_analysis");
 
 const BASE_LEG = {
   ticker: "SPY260105C00470000",
@@ -56,22 +81,86 @@ function pnlPath(values: number[]) {
   }));
 }
 
-async function runAnalyzeTool(input: Record<string, unknown>, path: number[]) {
+const ENTRY_COST_TERMS = [-0.52964374, -0.774253, 0.52964374, 0.774253, 0.0000005];
+
+function exactEntryCostReplay(order: number[], pnl = 0) {
+  const legs = order.map((termIndex, index) => ({
+    occTicker: `SPY260105C${String(47000000 + index).padStart(8, "0")}`,
+    quantity: Math.sign(ENTRY_COST_TERMS[termIndex]),
+    entryPrice: Math.abs(ENTRY_COST_TERMS[termIndex]),
+    multiplier: 1,
+  }));
+  const pnlLegIndex = legs.findIndex((leg) => leg.quantity > 0);
+  const barsByLeg = legs.map((leg, index) => {
+    const mark = leg.entryPrice + (index === pnlLegIndex ? pnl : 0);
+    return ["09:30", "09:31"].map((time) => ({
+      date: "2026-01-05",
+      time,
+      open: mark,
+      high: mark,
+      low: mark,
+      close: mark,
+      volume: 1,
+      ticker: leg.occTicker,
+    }));
+  });
+  return { legs, pnlPath: computeStrategyPnlPath(legs, barsByLeg) };
+}
+
+function explicitLegs(replay: ReturnType<typeof exactEntryCostReplay>) {
+  return replay.legs.map((leg) => ({
+    ...BASE_LEG,
+    ticker: leg.occTicker,
+    quantity: leg.quantity,
+    entry_price: leg.entryPrice,
+  }));
+}
+
+async function runExactAnalyze(order: number[], pnl = 0) {
+  const replay = exactEntryCostReplay(order, pnl);
+  handleReplayTrade.mockResolvedValueOnce(replay);
+  return runAnalyzeTool(
+    {
+      legs: explicitLegs(replay),
+      multiplier: 1,
+      triggers: [{ type: "profitTarget", unit: "percent", threshold: 1 }],
+    },
+    [],
+    false,
+  );
+}
+
+async function runExactBatch(order: number[], pnl = 0) {
+  handleReplayTrade.mockResolvedValueOnce(exactEntryCostReplay(order, pnl));
+  const parsed = batchSchema.parse({
+    block_id: "exact-entry-cost",
+    candidate_policy: [{ type: "profitTarget", unit: "percent", threshold: 1 }],
+    baseline_mode: "actual",
+    limit: 1,
+    multiplier: 1,
+    format: "full",
+  });
+  return batchHandler(parsed);
+}
+
+async function runAnalyzeTool(input: Record<string, unknown>, path: number[], mockReplay = true) {
   const parsed = schema.parse(input);
   const legs = parsed.legs as Array<{
     ticker: string;
     quantity: number;
     entry_price: number;
   }>;
-  handleReplayTrade.mockResolvedValueOnce({
-    pnlPath: pnlPath(path),
-    legs: legs.map((leg) => ({
-      occTicker: leg.ticker,
-      quantity: leg.quantity,
-      entryPrice: leg.entry_price,
-      multiplier: parsed.multiplier,
-    })),
-  });
+  if (mockReplay) {
+    handleReplayTrade.mockResolvedValueOnce({
+      pnlPath: pnlPath(path),
+      legs: legs.map((leg) => ({
+        occTicker: leg.ticker,
+        quantity: leg.quantity,
+        entryPrice: leg.entry_price,
+        multiplier: parsed.multiplier,
+      })),
+    });
+  }
   return handler(parsed);
 }
 
@@ -87,6 +176,33 @@ function analysis(result: ToolResult) {
 }
 
 describe("registered analyze_exit_triggers money boundaries", () => {
+  const authoredOrder = [0, 1, 2, 3, 4];
+  const reversedOrder = [...authoredOrder].reverse();
+
+  it("derives the same percentage threshold across authored leg orders", async () => {
+    const results = await Promise.all([
+      runExactAnalyze(authoredOrder, 0.000001),
+      runExactAnalyze(reversedOrder, 0.000001),
+    ]);
+
+    for (const result of results) {
+      const firstToFire = analysis(result).overall.firstToFire;
+      expect(firstToFire).not.toBeNull();
+      expect(firstToFire!.detail).toContain("($0.000001)");
+    }
+  });
+
+  it("makes the same zero-P&L exit decision across authored leg orders", async () => {
+    const results = await Promise.all([
+      runExactAnalyze(authoredOrder),
+      runExactAnalyze(reversedOrder),
+    ]);
+
+    for (const result of results) {
+      expect(analysis(result).overall.firstToFire).toBeNull();
+    }
+  });
+
   it("analyses a percentage target after near-cancelling explicit leg prices", async () => {
     const result = await runAnalyzeTool(
       {
@@ -138,5 +254,37 @@ describe("registered analyze_exit_triggers money boundaries", () => {
     expect(data.overall.firstToFire).not.toBeNull();
     expect(data.overall.firstToFire!.pnlAtFire).toBe(resolvedTarget);
     expect(data.overall.firstToFire!.detail).toContain("target $281474976.710656");
+  });
+});
+
+describe("registered batch_exit_analysis money boundaries", () => {
+  it("derives the same percentage threshold across authored leg orders", async () => {
+    const authoredOrder = [0, 1, 2, 3, 4];
+    for (const order of [authoredOrder, [...authoredOrder].reverse()]) {
+      const result = await runExactBatch(order, 0.000001);
+      expect(result.isError).not.toBe(true);
+      const trade = (
+        result.structuredContent as {
+          perTrade: Array<{ triggerFired: string; candidatePnl: number }>;
+        }
+      ).perTrade[0];
+      expect(trade.triggerFired).toBe("profitTarget");
+      expect(trade.candidatePnl).toBe(0.000001);
+    }
+  });
+
+  it("makes the same zero-P&L exit decision across authored leg orders", async () => {
+    const authoredOrder = [0, 1, 2, 3, 4];
+    const results = [];
+    for (const order of [authoredOrder, [...authoredOrder].reverse()]) {
+      const result = await runExactBatch(order);
+      expect(result.isError).not.toBe(true);
+      results.push(
+        (result.structuredContent as { perTrade: Array<{ triggerFired: string }> }).perTrade[0]
+          .triggerFired,
+      );
+    }
+
+    expect(results).toEqual(["noTrigger", "noTrigger"]);
   });
 });

--- a/packages/mcp-server/tests/unit/exit-threshold-precision.test.ts
+++ b/packages/mcp-server/tests/unit/exit-threshold-precision.test.ts
@@ -19,8 +19,10 @@ import {
   evaluateTrigger,
   analyzeExitTriggers,
   analyzeExitTriggersSchema,
+  computeStrategyPnlPath,
   type ExitTriggerConfig,
 } from "../../src/test-exports.ts";
+import type { BarRow } from "../../src/utils/market-provider.ts";
 import type { PnlPoint, ReplayLeg } from "../../src/utils/trade-replay.ts";
 
 const LEGS: ReplayLeg[] = [
@@ -35,6 +37,38 @@ function pathOf(pnls: number[]): PnlPoint[] {
     legPrices: [5.0, 3.0],
     netDelta: null,
   }));
+}
+
+const EXACT_POSITION = [
+  { mark: 0.865, entry: 0.845, quantity: 1 },
+  { mark: 1.59, entry: 0.255, quantity: -1 },
+  { mark: 1.635, entry: 0.095, quantity: 1 },
+  { mark: 1.54, entry: 1.505, quantity: -1 },
+];
+
+function replayPosition(
+  values: typeof EXACT_POSITION,
+  quantitySign: 1 | -1 = 1,
+): { legs: ReplayLeg[]; pnlPath: PnlPoint[] } {
+  const legs: ReplayLeg[] = values.map((leg, index) => ({
+    occTicker: `LEG${index}`,
+    quantity: leg.quantity * quantitySign,
+    entryPrice: leg.entry,
+    multiplier: 100,
+  }));
+  const bars: BarRow[][] = values.map((leg, index) => [
+    {
+      date: "2026-01-05",
+      time: "09:30",
+      open: leg.mark,
+      high: leg.mark,
+      low: leg.mark,
+      close: leg.mark,
+      volume: 10,
+      ticker: `LEG${index}`,
+    },
+  ]);
+  return { legs, pnlPath: computeStrategyPnlPath(legs, bars) };
 }
 
 /** Dollar figures a detail line reports, e.g. "... (-$0.35)" -> [0.35]. */
@@ -101,6 +135,76 @@ describe("a threshold reached by arithmetic behaves like one written down", () =
     const result = evaluateTrigger(trigger, pathOf([0, 7.275]), LEGS);
     expect(result).not.toBeNull();
     expect(result!.detail).toContain("$7.275");
+  });
+});
+
+describe("replayed P&L reaches exact exit boundaries independent of leg order", () => {
+  it("fires a profit target in both authored orders", () => {
+    for (const values of [EXACT_POSITION, [...EXACT_POSITION].reverse()]) {
+      const { legs, pnlPath } = replayPosition(values);
+      const result = evaluateTrigger(
+        { type: "profitTarget", threshold: 19, requiredHits: 1 },
+        pnlPath,
+        legs,
+      );
+      expect(result?.type).toBe("profitTarget");
+    }
+  });
+
+  it("fires a stop loss in both authored orders", () => {
+    for (const values of [EXACT_POSITION, [...EXACT_POSITION].reverse()]) {
+      const { legs, pnlPath } = replayPosition(values, -1);
+      const result = evaluateTrigger({ type: "stopLoss", threshold: 19 }, pnlPath, legs);
+      expect(result?.type).toBe("stopLoss");
+    }
+  });
+
+  it("arms and stops a profit action at an arithmetic equality", () => {
+    const { legs, pnlPath } = replayPosition(EXACT_POSITION);
+    const result = evaluateTrigger(
+      {
+        type: "profitAction",
+        threshold: 0,
+        steps: [{ armAt: 19, stopAt: 19 }],
+      },
+      pnlPath,
+      legs,
+    );
+    expect(result?.type).toBe("profitAction");
+  });
+});
+
+describe("a trailing stop is reached when its exact dropdown equals the trail", () => {
+  it.each([
+    [300_013 / 1_000_000, 125_013 / 1_000_000],
+    [-300_013 / 1_000_000, -475_013 / 1_000_000],
+  ])("fires from a peak of %s to a P&L of %s", (peak, pnl) => {
+    const result = evaluateTrigger(
+      { type: "trailingStop", threshold: 0.175 },
+      pathOf([peak, pnl]),
+      LEGS,
+    );
+    expect(result?.type).toBe("trailingStop");
+  });
+});
+
+describe("actual-exit P&L differences stay in the exact money domain", () => {
+  it("reports equivalent arithmetic P&Ls as the same", () => {
+    const authored = replayPosition(EXACT_POSITION).pnlPath[0];
+    const reversed = replayPosition([...EXACT_POSITION].reverse()).pnlPath[0];
+    const pnlPath = [
+      { ...authored, timestamp: "2026-01-05 09:30" },
+      { ...reversed, timestamp: "2026-01-05 09:31" },
+    ];
+    const result = analyzeExitTriggers({
+      triggers: [{ type: "clockTimeExit", threshold: 0, clockTime: "09:30" }],
+      pnlPath,
+      legs: LEGS,
+      actualExitTimestamp: pnlPath[1].timestamp,
+    });
+
+    expect(result.overall.actualExit?.pnlDifference).toBe(0);
+    expect(result.overall.summary).toContain("Trigger was the same.");
   });
 });
 

--- a/packages/mcp-server/tests/unit/exit-triggers.test.ts
+++ b/packages/mcp-server/tests/unit/exit-triggers.test.ts
@@ -956,6 +956,68 @@ describe("analyzeExitTriggers", () => {
 // ---------------------------------------------------------------------------
 
 describe("leg groups", () => {
+  const exactGroupLegs: ReplayLeg[] = [
+    { occTicker: "LEG0", quantity: 1, entryPrice: 0.845, multiplier: 100 },
+    { occTicker: "LEG1", quantity: -1, entryPrice: 0.255, multiplier: 100 },
+    { occTicker: "LEG2", quantity: 1, entryPrice: 0.095, multiplier: 100 },
+    { occTicker: "LEG3", quantity: -1, entryPrice: 1.505, multiplier: 100 },
+  ];
+  const exactGroupPath = buildTestPath([19], {
+    legPrices: [[0.865, 1.59, 1.635, 1.54]],
+  });
+
+  it("produces exact group P&L independent of the group's leg order", () => {
+    const result = analyzeExitTriggers({
+      pnlPath: exactGroupPath,
+      legs: exactGroupLegs,
+      triggers: [],
+      legGroups: [
+        { label: "authored", legIndices: [0, 1, 2, 3], triggers: [] },
+        { label: "reversed", legIndices: [3, 2, 1, 0], triggers: [] },
+      ],
+    });
+
+    expect(result.legGroups?.[0].groupPnl[0]).toBe(19);
+    expect(result.legGroups?.[1].groupPnl[0]).toBe(19);
+  });
+
+  it("fires group profit targets at arithmetic equality in either leg order", () => {
+    const trigger: ExitTriggerConfig = {
+      type: "profitTarget",
+      threshold: 19,
+      requiredHits: 1,
+    };
+    const result = analyzeExitTriggers({
+      pnlPath: exactGroupPath,
+      legs: exactGroupLegs,
+      triggers: [],
+      legGroups: [
+        { label: "authored", legIndices: [0, 1, 2, 3], triggers: [trigger] },
+        { label: "reversed", legIndices: [3, 2, 1, 0], triggers: [trigger] },
+      ],
+    });
+
+    expect(result.legGroups?.[0].result.firstToFire?.type).toBe("profitTarget");
+    expect(result.legGroups?.[1].result.firstToFire?.type).toBe("profitTarget");
+  });
+
+  it("fires group stop losses at arithmetic equality in either leg order", () => {
+    const lossLegs = exactGroupLegs.map((leg) => ({ ...leg, quantity: -leg.quantity }));
+    const trigger: ExitTriggerConfig = { type: "stopLoss", threshold: 19 };
+    const result = analyzeExitTriggers({
+      pnlPath: exactGroupPath,
+      legs: lossLegs,
+      triggers: [],
+      legGroups: [
+        { label: "authored", legIndices: [0, 1, 2, 3], triggers: [trigger] },
+        { label: "reversed", legIndices: [3, 2, 1, 0], triggers: [trigger] },
+      ],
+    });
+
+    expect(result.legGroups?.[0].result.firstToFire?.type).toBe("stopLoss");
+    expect(result.legGroups?.[1].result.firstToFire?.type).toBe("stopLoss");
+  });
+
   it("computes per-group P&L correctly", () => {
     // Two legs: leg 0 (short call, qty=-1, entry=5.0), leg 1 (long call, qty=1, entry=3.0)
     const legPrices = [

--- a/packages/mcp-server/tests/unit/trade-replay.test.ts
+++ b/packages/mcp-server/tests/unit/trade-replay.test.ts
@@ -211,6 +211,40 @@ describe("buildOccTicker", () => {
 });
 
 describe("computeStrategyPnlPath", () => {
+  it("produces exact order-invariant P&L across multiple legs", () => {
+    const legValues = [
+      { mark: 0.865, entry: 0.845, quantity: 1 },
+      { mark: 1.59, entry: 0.255, quantity: -1 },
+      { mark: 1.635, entry: 0.095, quantity: 1 },
+      { mark: 1.54, entry: 1.505, quantity: -1 },
+    ];
+
+    const replay = (values: typeof legValues) => {
+      const legs: ReplayLeg[] = values.map((leg, index) => ({
+        occTicker: `LEG${index}`,
+        quantity: leg.quantity,
+        entryPrice: leg.entry,
+        multiplier: 100,
+      }));
+      const bars: BarRow[][] = values.map((leg, index) => [
+        {
+          date: "2025-01-17",
+          time: "09:31",
+          open: leg.mark,
+          high: leg.mark,
+          low: leg.mark,
+          close: leg.mark,
+          volume: 10,
+          ticker: `LEG${index}`,
+        },
+      ]);
+      return computeStrategyPnlPath(legs, bars)[0].strategyPnl;
+    };
+
+    expect(replay(legValues)).toBe(19);
+    expect(replay([...legValues].reverse())).toBe(19);
+  });
+
   it("computes P&L for single leg with 3 bars", () => {
     const legs: ReplayLeg[] = [
       { occTicker: "SPY250117C00470000", quantity: 1, entryPrice: 5.0, multiplier: 100 },

--- a/releases/v3.10.0.md
+++ b/releases/v3.10.0.md
@@ -25,9 +25,11 @@ figure it reports, but re-run any saved analysis you are relying on.
 
 Replayed position P&L, per-leg-group P&L, trailing drops, and
 trigger-versus-actual-exit differences now resolve to the same
-nearest-millionth-of-a-dollar grid used by exit thresholds. Entry costs used for
-percentage exits are also resolved per leg before they are combined, so leg order
-cannot change the threshold. **An analysis sitting exactly on one of these
+nearest-millionth-of-a-dollar grid used by exit thresholds. For analyses that
+complete, entry costs used for percentage exits are also resolved per leg before
+they are combined, so leg order cannot change the threshold. A position outside
+the supported money range fails with an error instead of returning a wrong
+result. **An analysis sitting exactly on one of these
 boundaries may now gain or lose an exit compared with an earlier result.** Re-run
 any saved analysis you rely on. Reported P&L figures keep their existing
 two-decimal presentation.

--- a/releases/v3.10.0.md
+++ b/releases/v3.10.0.md
@@ -23,12 +23,14 @@ inclusive. **An exit analysis at one of these boundaries may now gain or lose a
 trigger compared with an earlier result.** The new result uses the resolved
 figure it reports, but re-run any saved analysis you are relying on.
 
-This change does not alter the P&L path, per-leg-group P&L calculation, or the
-subtraction used to calculate a trailing drop. Those values are still calculated
-with binary floating-point arithmetic and retain the same class of boundary
-defect: a group P&L or trailing drop can land just below a decimal amount it
-mathematically equals. Reported P&L figures also keep their existing two-decimal
-presentation.
+Replayed position P&L, per-leg-group P&L, trailing drops, and
+trigger-versus-actual-exit differences now resolve to the same
+nearest-millionth-of-a-dollar grid used by exit thresholds. Entry costs used for
+percentage exits are also resolved per leg before they are combined, so leg order
+cannot change the threshold. **An analysis sitting exactly on one of these
+boundaries may now gain or lose an exit compared with an earlier result.** Re-run
+any saved analysis you rely on. Reported P&L figures keep their existing
+two-decimal presentation.
 
 Three further consequences:
 


### PR DESCRIPTION
## What it does

Exit analysis now decides on P&L figures that are exact decimal money, the same way #419 made exit
*thresholds* exact.

#419 brought every derived threshold into a fixed-point micro-dollar domain. It deliberately left
the P&L those thresholds are compared against alone, on the stated grounds that the P&L "arrives
already computed from the replay." That premise was not right: this package computes that P&L
itself, in `utils/trade-replay.ts`, in binary floating point — subtracting prices before entering
the domain and summing legs left to right.

Binary addition is not associative, so the authored leg order changed the answer. A four-leg
position at ordinary half-cent prices with a **$19.00 dollar profit target**:

```
exact P&L                19
this package's P&L       18.999999999999986   -> reported the target as NOT reached
```

## Why it is worth fixing rather than tolerating

Like #419, the error is small in dollars and structural in kind. Three properties make it more than
noise:

- **It is not stable.** The same position, with its legs written in a different order, produced a
  different P&L and could produce a different exit decision. Nothing about a position's economics
  changes when its legs are reordered.
- **It always resolved the same direction** at a boundary — against the threshold being met.
- **It landed where operators actually configure.** Whole-dollar and round-percentage targets are
  exactly the values that fall on the grid.

The trailing stop was worse, because it subtracts two P&L values. Over 1,200,000 sampled
comparisons the binary dropdown and the exact dropdown reached different decisions 58,611 times,
and the disagreements landed on exact equality — the trail was precisely met and the analysis
reported that it was not.

## The approach

The same representational fix as #419, applied to the values the thresholds are compared against.
No epsilon, no tolerance, no rounding policy — an exactly representable domain has no "just below
half" case to have a policy about.

Five arithmetic sites moved into the existing `utils/money.ts` domain:

| Site | Change |
|---|---|
| `utils/trade-replay.ts` | Whole-position P&L: each leg's price difference is taken inside the domain, legs are added as exact integers, one conversion out |
| `utils/exit-triggers.ts` | Per-leg-group P&L: same shape |
| `utils/exit-triggers.ts` | Trailing-stop dropdown: the subtraction stays in the domain |
| `utils/exit-triggers.ts` | Overall and per-group trigger-versus-actual-exit differences: same |
| `tools/exit-analysis.ts`, `tools/batch-exit-analysis.ts` | Percentage-trigger entry cost: each signed leg term is resolved before the terms are combined |

That last one is the subtle one. Snapping only the final total does not fix it: with terms that
cancel, the running sum can land either side of a rounding boundary depending on order. Terms
`[-0.52964374, -0.774253, 0.52964374, 0.774253, 0.0000005]` summed forward give
`5.000000001110223e-7` and reversed give `4.999999999588667e-7` — one resolves to a micro-dollar
and the other to zero, which changed a 100% profit-target decision against a zero P&L. Resolving
each complete signed term before adding removes it.

Terms are converted whole rather than converting the price first and scaling after, so the
fractional quantities and multipliers the public interface accepts keep working; each leg still
resolves independently, so the result stays independent of leg order.

## Behaviour and compatibility

- **Positions sitting exactly at a target, stop, trailing drop, or stepped-action boundary now exit
  at that boundary.** They could previously stay open. This is the defect being fixed, and it is a
  visible change in what an analysis reports.
- **Comparisons stay inclusive.** Only the operands change, exactly as in #419.
- **No public API change.** No export added, removed, or altered; `utils/money.ts` remains internal
  and is not a package subpath export. Verified by resolution, not by inspection — deep imports of
  the money, replay and exit-trigger modules all fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and all
  29 export entries still resolve.
- **Reported figures keep their two-decimal presentation.**
- `releases/v3.10.0.md` is corrected: it previously stated that this class of defect remained in the
  P&L path, group P&L and trailing drop, which is no longer true.

### One boundary stated honestly

At the extreme edge of the representable range — legs in the billions of dollars — an intermediate
sum can leave exact range for one leg ordering and not another. That case **fails loudly**: the
single tool returns an explicit error, and the batch tool records the trade in `skippedTrades`,
names it in the summary, and completes the rest of the run. It never returns a wrong answer
silently. The release note bounds the leg-order guarantee to analyses that complete rather than
claiming more than holds.

## Verification

| Gate | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run build:mcp` | clean |
| `npm run test --workspace=tradeblocks-mcp` | **142 suites, 1877 tests, all passing** |

**The new behavioural tests were run against the previous behaviour first: 9 of 10 failed.** The
tenth — trailing-stop equality in a negative P&L regime — passed beforehand, because that
particular binary error happened to land above equality rather than below it. Recording that rather
than rounding it up to ten.

Tests cover what the previous round missed: values arrived at by arithmetic rather than written as
clean literals, the same position with its legs in different orders, and exact-equality boundaries
in both directions. Clean literals are why this survived #419.

The entry-cost regression drives both **registered tool handlers** — `analyze_exit_triggers` and
`batch_exit_analysis` — with P&L produced by the production replay path rather than a mock, so it
proves the tool an operator actually calls, not just the helpers underneath it. Against the
unrepaired code it failed 3 of 6: the reversed-order threshold reported `$0.00` instead of
`$0.000001`, and a reversed-order zero-P&L fired in both tools.

A further regression covers the out-of-range case above and asserts that one bad trade does not
fail a whole batch run.

No pre-existing test assertion was removed, weakened, or modified anywhere in this branch.

One environmental note, pre-existing and unrelated: the full suite needs an 8 GB Node heap or it
exhausts the default. Nothing in the test or repository configuration was changed for it.
