### PR TITLE
chore(deps): clear the four advisories failing the dependency audit on master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2352,9 +2352,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16939,9 +16939,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -18176,9 +18176,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -22106,9 +22106,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
-      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {


### PR DESCRIPTION
## What it does

Clears the four advisories currently failing `Dependency audit` on `master`.

`master` is red at `caff46a6`, which blocks every open pull request in this repository — the audit
job is not specific to any change in flight. The advisories were published against packages we
depend on **indirectly**; nothing in this repository's own dependency choices changed.

```
js-yaml     high      3.0.0 - 3.15.0 || 4.0.0 - 4.3.0   GHSA-5p4m-2wfm-xmqj
nanoid      high      <3.3.17                            GHSA-2v37-7h3g-55p8
protobufjs  moderate  7.5.0 - 7.6.4                      GHSA-j3f2-48v5-ccww
valibot     moderate  <=1.4.1                            GHSA-5qjj-4xww-7phc
```

## The change

**`package-lock.json` only** — 15 insertions, 15 deletions. All five moves are patch-level.

| Package | Reached through | Before | After |
|---|---|---|---|
| `js-yaml` | `@istanbuljs/load-nyc-config` | 3.15.0 | 3.15.1 |
| `js-yaml` | `@eslint/eslintrc` | 4.3.0 | 4.3.1 |
| `nanoid` | `postcss` | 3.3.16 | 3.3.18 |
| `protobufjs` | `@grpc/proto-loader` | 7.6.4 | 7.6.5 |
| `valibot` | `repomix` | 1.4.1 | 1.4.2 |

No manifest change, no source change, no test change, no configuration change. No package outside
the four advisory names moved. The direct `protobufjs` dependency stays at 8.7.2.

**No override, no suppression, and no change to the audit level.** Each advisory is resolved by
taking the fixed version, not by hiding the finding — a silenced advisory reads as safety and is
not.

## Runtime exposure

A dependency change that leaves the suite green is not automatically safe, so stated explicitly:

- **Runtime** — the nested `protobufjs` is reachable from the shipped MCP server via
  `@grpc/proto-loader` when the opt-in ThetaData MDDS provider connects. Patch bump; build and the
  relevant tests pass.
- **Build only** — `nanoid` is reached through PostCSS for CSS processing; not imported by
  application source.
- **Lint and test only** — both `js-yaml` copies, via ESLint and Istanbul/Jest.
- **Developer tooling only** — `valibot`, via the `repomix` dev dependency.

## Verification

| Gate | Result |
|---|---|
| `npm audit --audit-level=high` | **`found 0 vulnerabilities`** (was 4: 2 high, 2 moderate) |
| `npm run typecheck` | clean |
| `npm run lint` | clean |
| `npm run format:check` | clean |
| `npm run build:mcp` | clean |
| `npm run test --workspace=tradeblocks-mcp` | 142 suites, 1861 tests, all passing |
