### PR TITLE
fix(mcp-server): enricher indicator series and lookahead-free LAG contain only genuine sessions (enterprise#2871)

### DIFF
--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -25,6 +25,11 @@
 
 import { DEFAULT_MARKET_TICKER } from "./ticker.ts";
 import { SCHEMA_DESCRIPTIONS } from "./schema-metadata.ts";
+import {
+  XNYS_SESSION_CALENDAR_SUPPORTED_FROM,
+  XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH,
+  isXnysSessionDate,
+} from "../market/provenance/xnys-session-calendar.ts";
 
 const dailyColumns = SCHEMA_DESCRIPTIONS.market.tables.enriched.columns;
 const derivedColumns = SCHEMA_DESCRIPTIONS.market.tables.enriched_context.columns;
@@ -246,6 +251,68 @@ function buildVixSelectCols(): string {
   return VIX_ALL_MAPPINGS.map((m) => `${m.tableAlias}."${m.sourceCol}" AS "${m.alias}"`).join(", ");
 }
 
+// ============================================================================
+// Session-bounded LAG source
+//
+// The lookahead-free contract is "an index lag of one position means the prior
+// SESSION". market.enriched may legitimately contain all-null non-session
+// identity rows (Tier 3 timing writes, working-table backfill), and LAG() over
+// the unfiltered history makes the first genuine session after such a row lag
+// to NULL (or to a stale valued row). The enricher already filters these rows
+// out of its indicator series; this predicate applies the same bounded-calendar
+// doctrine on the analysis plane: inside the calendar revision's supported
+// range only genuine XNYS sessions feed LAG; dates OUTSIDE the range stay
+// LAG-consumed exactly as today — the calendar has no opinion there and legacy
+// history must keep providing the first in-range prior values.
+//
+// Published row presence is untouched: only the LAG input set changes.
+// ============================================================================
+
+let weekdayClosureCache: string[] | null = null;
+
+/**
+ * Weekday dates inside the supported calendar range that are NOT XNYS
+ * sessions. Derived from the same authority as the enricher filter, so
+ * "weekday AND not in this list" is exactly "is a session" in-range by
+ * construction. Weekend non-sessions are handled by the dow test instead of
+ * enumeration to keep the emitted SQL small.
+ */
+function xnysWeekdayClosures(): string[] {
+  if (weekdayClosureCache) return weekdayClosureCache;
+  const closures: string[] = [];
+  const cursor = new Date(`${XNYS_SESSION_CALENDAR_SUPPORTED_FROM}T00:00:00.000Z`);
+  const through = new Date(`${XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH}T00:00:00.000Z`);
+  while (cursor.getTime() <= through.getTime()) {
+    const iso = cursor.toISOString().slice(0, 10);
+    if (!isXnysSessionDate(iso)) {
+      const weekday = cursor.getUTCDay();
+      if (weekday !== 0 && weekday !== 6) closures.push(iso);
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  weekdayClosureCache = closures;
+  return closures;
+}
+
+/**
+ * SQL predicate over a `date` column: keep out-of-range rows unconditionally,
+ * and in-range keep only genuine XNYS sessions. DuckDB `dow` is PostgreSQL-
+ * compatible (Sunday=0 .. Saturday=6).
+ */
+function xnysSessionLagFilterSql(): string {
+  const closureLiterals = xnysWeekdayClosures()
+    .map((date) => `'${date}'`)
+    .join(", ");
+  return `(
+        date < '${XNYS_SESSION_CALENDAR_SUPPORTED_FROM}'
+        OR date > '${XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH}'
+        OR (
+          EXTRACT(dow FROM CAST(date AS DATE)) NOT IN (0, 6)
+          AND CAST(date AS DATE) NOT IN (${closureLiterals})
+        )
+      )`;
+}
+
 // SELECT columns from enriched_context: cd."Vol_Regime", ...
 function buildDerivedSelectCols(): string {
   return [...DERIVED_OPEN_FIELDS, ...DERIVED_CLOSE_FIELDS].map((f) => `cd."${f}"`).join(", ");
@@ -328,6 +395,46 @@ export function buildLookaheadFreeQuery(tradeDatesOrKeys: string[] | MarketLooku
     .join(", ");
   const derivedOpenPassthrough = [...DERIVED_OPEN_FIELDS].map((f) => `"${f}"`).join(", ");
 
+  // Prior-value columns projected from the session-filtered LAG subquery. The
+  // outer `lagged` CTE keeps every joined row — output row presence is
+  // unchanged — but prev_* values exist only for rows that survived
+  // lag_input's XNYS-session filter, so a LAG never lands on an all-null
+  // non-session identity row. A requested non-session identity row keeps its
+  // output row with null priors: there is no meaningful prior-session lookup
+  // for a day the market was closed.
+  const dailyPrevCols = [...DAILY_CLOSE_FIELDS].map((f) => `l."prev_${f}"`).join(",\n        ");
+  const vixPrevCols = VIX_ALL_MAPPINGS.filter((m) => m.timing === "close")
+    .map((m) => `l."prev_${m.alias}"`)
+    .join(",\n        ");
+  const derivedPrevCols = [...DERIVED_CLOSE_FIELDS].map((f) => `l."prev_${f}"`).join(",\n        ");
+
+  const sessionBoundedLagCtes = `lag_input AS (
+      SELECT * FROM joined
+      WHERE ${xnysSessionLagFilterSql()}
+    ),
+    lagged AS (
+      SELECT
+        joined.ticker,
+        joined.date,
+        ${dailyOpenPassthrough},
+        ${dailyStaticPassthrough},
+        ${vixOpenPassthrough ? vixOpenPassthrough + "," : ""}
+        ${derivedOpenPassthrough ? derivedOpenPassthrough + "," : ""}
+        ${dailyPrevCols},
+        ${vixPrevCols ? vixPrevCols + "," : ""}
+        ${derivedPrevCols}
+      FROM joined
+      LEFT JOIN (
+        SELECT
+          ticker,
+          date,
+          ${dailyLagCols},
+          ${vixLagCols ? vixLagCols + "," : ""}
+          ${derivedLagCols}
+        FROM lag_input
+      ) l ON l.ticker = joined.ticker AND l.date = joined.date
+    )`;
+
   // Legacy path for existing date-only callers (single ticker = DEFAULT_MARKET_TICKER)
   if (typeof tradeDatesOrKeys[0] === "string") {
     const tradeDates = tradeDatesOrKeys as string[];
@@ -348,19 +455,7 @@ export function buildLookaheadFreeQuery(tradeDatesOrKeys: string[] | MarketLooku
       LEFT JOIN market.enriched_context cd ON cd.date = d.date
       WHERE d.ticker = $${tradeDates.length + 1}
     ),
-    lagged AS (
-      SELECT
-        ticker,
-        date,
-        ${dailyOpenPassthrough},
-        ${dailyStaticPassthrough},
-        ${vixOpenPassthrough ? vixOpenPassthrough + "," : ""}
-        ${derivedOpenPassthrough ? derivedOpenPassthrough + "," : ""}
-        ${dailyLagCols},
-        ${vixLagCols ? vixLagCols + "," : ""}
-        ${derivedLagCols}
-      FROM joined
-    )
+    ${sessionBoundedLagCtes}
     SELECT * FROM lagged
     WHERE date IN (${placeholders})`;
 
@@ -397,19 +492,7 @@ export function buildLookaheadFreeQuery(tradeDatesOrKeys: string[] | MarketLooku
       LEFT JOIN market.enriched_context cd ON cd.date = d.date
       WHERE d.ticker IN (SELECT DISTINCT ticker FROM requested)
     ),
-    lagged AS (
-      SELECT
-        ticker,
-        date,
-        ${dailyOpenPassthrough},
-        ${dailyStaticPassthrough},
-        ${vixOpenPassthrough ? vixOpenPassthrough + "," : ""}
-        ${derivedOpenPassthrough ? derivedOpenPassthrough + "," : ""}
-        ${dailyLagCols},
-        ${vixLagCols ? vixLagCols + "," : ""}
-        ${derivedLagCols}
-      FROM joined
-    )
+    ${sessionBoundedLagCtes}
     SELECT lagged.*
     FROM lagged
     JOIN requested

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -268,6 +268,11 @@ function buildVixSelectCols(): string {
 // Published row presence is untouched: only the LAG input set changes.
 // ============================================================================
 
+// Computed once and never invalidated for the life of the process — only a
+// restart rebuilds it. Safe because every input is a deploy-time constant:
+// the supported range (2022-01-01..2030-12-31) and the closure rules ship in
+// xnys-session-calendar.ts (revision xnys-full-day-2022-2030-v1); nothing
+// here reads runtime-mutable state.
 let weekdayClosureCache: string[] | null = null;
 
 /**

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -273,6 +273,10 @@ function buildVixSelectCols(): string {
 // the supported range (2022-01-01..2030-12-31) and the closure rules ship in
 // xnys-session-calendar.ts (revision xnys-full-day-2022-2030-v1); nothing
 // here reads runtime-mutable state.
+// Test hazard: nothing clears this between tests either — a test that stubs
+// isXnysSessionDate or expects a different calendar can silently read
+// closures computed from the real calendar by an earlier test in the same
+// process.
 let weekdayClosureCache: string[] | null = null;
 
 /**

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -341,9 +341,13 @@ function buildDerivedSelectCols(): string {
  * Pitfall 1: market.enriched carries NO OHLCV columns; OHLCV projections MUST use the
  * spot_daily alias (`s` for the target ticker, `vix/vix9d/vix3m` for VIX-family).
  *
- * LAG operates on the FULL ticker history (all trading days for the ticker),
- * NOT just the requested dates. This ensures LAG sees the correct prior trading day
- * across weekends, holidays, and sparse trading strategies.
+ * LAG consumes each ticker's full row history, NOT just the requested dates. Its
+ * source set (`lag_input`) is session-filtered by xnysSessionLagFilterSql(): inside
+ * the supported XNYS calendar range (2022-01-01..2030-12-31) only genuine XNYS
+ * sessions feed LAG, so weekend/holiday gaps and all-null non-session identity
+ * rows never become the prior day; rows dated outside that window remain
+ * LAG-consumed exactly as before (the calendar has no opinion there). This keeps
+ * the lookahead-free contract: an index lag of one position is the prior SESSION.
  *
  * @param tradeDatesOrKeys - Array of dates (legacy string[] overload) or ticker+date keys
  * @returns Object with `sql` (the query string) and `params` (the parameter values)

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -626,7 +626,19 @@ function normalizeMarketRowDate(value: unknown): string {
   // DuckDB DATE internal repr: int32 days since 1970-01-01 UTC
   const days = (value as { days?: unknown } | null)?.days;
   if (typeof days === "number" && Number.isInteger(days)) {
-    return new Date(days * 24 * 60 * 60 * 1_000).toISOString().slice(0, 10);
+    const iso = new Date(days * 24 * 60 * 60 * 1_000).toISOString().slice(0, 10);
+    // Plausibility bound, not calendar authority: dates outside the XNYS
+    // supported range are legitimate (legacy history stays usable), so
+    // 1900-2100 deliberately brackets any plausible trade history while
+    // making corrupt vendor day counts refuse loudly instead of producing
+    // valid-looking far-future dates that no downstream stage questions.
+    const year = Number(iso.slice(0, 4));
+    if (year < 1900 || year > 2100) {
+      throw new TypeError(
+        `OHLCV source returned an implausible DuckDB DATE ${iso}: ${days} days since 1970-01-01 UTC falls outside the plausible 1900-2100 window`,
+      );
+    }
+    return iso;
   }
   throw new TypeError(
     `OHLCV source returned a date that is not a real calendar date: ${JSON.stringify(value)}`,

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -602,6 +602,36 @@ function parseDateStr(dateStr: string): Date | null {
   return new Date(parseInt(m[1]), parseInt(m[2]) - 1, parseInt(m[3]));
 }
 
+const ISO_CALENDAR_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Normalize an OHLCV row's date value to a validated YYYY-MM-DD string at the
+ * rawRows boundary. The legacy SQL fallback reads `market.spot_daily`, which
+ * may be a view over Hive-partitioned Parquet whose `date` partition value
+ * DuckDB auto-casts to DATE; the node-api reader then yields a DuckDBDateValue
+ * object (JSON-shape `{"days":N}`), not a string. Every downstream consumer
+ * (zero-OHLC guard, session filter, watermark comparisons, writeRows) assumes
+ * real strings, so conversion happens once here — never at call sites.
+ */
+function normalizeMarketRowDate(value: unknown): string {
+  if (typeof value === "string" && ISO_CALENDAR_DATE_RE.test(value)) {
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    if (Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value) {
+      return value;
+    }
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString().slice(0, 10);
+  }
+  const days = (value as { days?: unknown } | null)?.days;
+  if (typeof days === "number" && Number.isInteger(days)) {
+    return new Date(days * 24 * 60 * 60 * 1_000).toISOString().slice(0, 10);
+  }
+  throw new TypeError(
+    `OHLCV source returned a date that is not a real calendar date: ${JSON.stringify(value)}`,
+  );
+}
+
 // =============================================================================
 // Parquet Enrichment Helpers
 // =============================================================================
@@ -1463,6 +1493,14 @@ export async function runEnrichment(
       );
       rawRows = rawReader.getRows();
     }
+
+    // 3a. Boundary normalization: the SQL fallback may read `market.spot_daily`
+    // over a Hive-partitioned Parquet view whose DATE-typed partition values
+    // arrive as DuckDBDateValue objects. Convert every row's date to a
+    // validated YYYY-MM-DD string once here so all downstream steps (zero-OHLC
+    // guard, session filter, watermark comparisons, array construction) see
+    // real strings regardless of which OHLCV source produced the rows.
+    rawRows = rawRows.map((r) => [r[0], normalizeMarketRowDate(r[1]), r[2], r[3], r[4], r[5]]);
 
     if (rawRows.length === 0) {
       return {

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -31,6 +31,7 @@ import type { SpotStore } from "../market/stores/spot-store.ts";
 import { isRealMarketSessionDate } from "../market/provenance/dataset-registry.ts";
 import {
   enumerateXnysSessions,
+  isXnysSessionDate,
   XNYS_SESSION_CALENDAR_SUPPORTED_FROM,
   XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH,
 } from "../market/provenance/xnys-session-calendar.ts";
@@ -1497,6 +1498,38 @@ export async function runEnrichment(
       );
     }
     rawRows = filteredRawRows;
+
+    // 3c. XNYS session filter. The indicator arrays must contain only genuine
+    // trading sessions so that "one position back" means "the prior session",
+    // never "the prior partition". The VIX spot feed carries priced full-day
+    // holiday partitions; without this filter the session after a holiday
+    // lags to the holiday's close (Prior_Close, Gap_Pct, Prev_Return_Pct,
+    // Prior_Range_vs_ATR) and every windowed indicator (RSI_14, ATR_Pct,
+    // EMA21, SMA50, Realized_Vol_5D/20D, Return_5D/20D) spans the wrong days.
+    // Canonical Parquet spot reads already exclude non-sessions at the store
+    // layer (SpotStore.buildDirectParquetReadBarsSQL); this second line of
+    // defense covers the legacy market.spot_daily fallback and store
+    // backends without partition-level calendar authority (DuckdbSpotStore).
+    // Dates outside the calendar revision's supported range are kept
+    // unfiltered — same doctrine as isCompleteXnysWindow: legacy physical
+    // data stays usable where the calendar authority has no opinion.
+    const sessionFilteredRawRows = rawRows.filter((r) => {
+      const date = r[1] as string;
+      if (
+        date < XNYS_SESSION_CALENDAR_SUPPORTED_FROM ||
+        date > XNYS_SESSION_CALENDAR_SUPPORTED_THROUGH
+      ) {
+        return true;
+      }
+      return isXnysSessionDate(date);
+    });
+    const nonSessionRowsDropped = rawRows.length - sessionFilteredRawRows.length;
+    if (nonSessionRowsDropped > 0) {
+      console.warn(
+        `[market-enricher] ticker=${ticker} dropped ${nonSessionRowsDropped} non-XNYS-session rows before indicator math`,
+      );
+    }
+    rawRows = sessionFilteredRawRows;
 
     // 4. Extract typed arrays from raw rows
     // Columns: ticker(0), date(1), open(2), high(3), low(4), close(5)

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -623,6 +623,7 @@ function normalizeMarketRowDate(value: unknown): string {
   if (value instanceof Date && Number.isFinite(value.getTime())) {
     return value.toISOString().slice(0, 10);
   }
+  // DuckDB DATE internal repr: int32 days since 1970-01-01 UTC
   const days = (value as { days?: unknown } | null)?.days;
   if (typeof days === "number" && Number.isInteger(days)) {
     return new Date(days * 24 * 60 * 60 * 1_000).toISOString().slice(0, 10);

--- a/packages/mcp-server/tests/unit/field-timing.test.ts
+++ b/packages/mcp-server/tests/unit/field-timing.test.ts
@@ -24,7 +24,11 @@ import {
   buildOutcomeQuery,
   buildVixJoinClause,
   SCHEMA_DESCRIPTIONS,
+  ensureMutableMarketTables,
+  ensureMarketDataTables,
 } from "../../src/test-exports.ts";
+import { DuckDBInstance } from "@duckdb/node-api";
+import type { DuckDBConnection, DuckDBInstance as DuckDBInstanceType } from "@duckdb/node-api";
 
 const dailyColumns = SCHEMA_DESCRIPTIONS.market.tables.enriched.columns;
 const dateContextColumns = SCHEMA_DESCRIPTIONS.market.tables.enriched_context.columns;
@@ -428,5 +432,129 @@ describe("buildVixJoinClause", () => {
   test("emits correct UPPER-cased ticker literal", () => {
     const sql = buildVixJoinClause(["vix3m"], "d");
     expect(sql).toContain("vix3m.ticker = 'VIX3M'");
+  });
+});
+
+// =============================================================================
+// Session-bounded LAG source (Worf gate rework, #2871 round 2)
+//
+// market.enriched can contain all-null non-session identity rows (Tier 3
+// timing writes / working-table backfill publish them). LAG() over the
+// unfiltered history made the first genuine session after such a row lag to
+// NULL on enrichment-derived fields and to the holiday's own close on OHLCV
+// fields joined from market.spot_daily. The lookahead-free contract requires
+// LAG to consume only genuine XNYS sessions inside the calendar revision's
+// supported range; out-of-range rows stay consumed (the calendar has no
+// opinion there).
+// =============================================================================
+
+describe("buildLookaheadFreeQuery session-bounded LAG source", () => {
+  let db: DuckDBInstanceType;
+  let conn: DuckDBConnection;
+
+  beforeEach(async () => {
+    db = await DuckDBInstance.create(":memory:");
+    conn = await db.connect();
+    await conn.run(`ATTACH ':memory:' AS market`);
+    await ensureMutableMarketTables(conn);
+    await ensureMarketDataTables(conn);
+    await conn.run(`
+      CREATE OR REPLACE VIEW market.spot_daily AS
+        SELECT ticker, date,
+               first(open ORDER BY time) AS open,
+               max(high)                 AS high,
+               min(low)                  AS low,
+               last(close ORDER BY time) AS close,
+               first(bid ORDER BY time)  AS bid,
+               last(ask ORDER BY time)   AS ask
+        FROM market.spot
+        WHERE time >= '09:30' AND time <= '16:00'
+        GROUP BY ticker, date
+    `);
+    const spotBars: Array<[string, number]> = [
+      ["2022-05-27", 4158.24], // last genuine session before the closure
+      ["2022-05-28", 4200.0], // priced Saturday partition — never a session
+      ["2022-05-30", 4148.5], // priced Memorial Day partition
+      ["2022-05-31", 4132.0], // first session after the closure
+    ];
+    for (const [date, close] of spotBars) {
+      await conn.run(
+        `INSERT INTO market.spot (ticker, date, time, open, high, low, close, bid, ask)
+         VALUES ('SPX', $1, '09:30', $2 - 1, $2 + 2, $2 - 2, $2, NULL, NULL)`,
+        [date, close],
+      );
+    }
+    // The 2022-05-28 and 2022-05-30 enriched rows are all-null identity rows —
+    // exactly what Tier 3 / backfill mechanics leave behind for non-session
+    // dates (weekend AND full-day closure).
+    await conn.run(`
+      INSERT INTO market.enriched (ticker, date, RSI_14) VALUES
+        ('SPX', '2022-05-27', 55.5),
+        ('SPX', '2022-05-28', NULL),
+        ('SPX', '2022-05-30', NULL),
+        ('SPX', '2022-05-31', 61.25)
+    `);
+  });
+
+  afterEach(() => {
+    try {
+      conn.closeSync();
+    } catch {
+      /* */
+    }
+    try {
+      db.closeSync();
+    } catch {
+      /* */
+    }
+  });
+
+  async function queryRecords(
+    keys: Array<{ ticker: string; date: string }>,
+  ): Promise<Array<Record<string, unknown>>> {
+    const { sql, params } = buildLookaheadFreeQuery(keys);
+    const reader = await conn.runAndReadAll(sql, params);
+    const names = Array.from({ length: reader.columnCount }, (_, i) => reader.columnName(i));
+    return Array.from(reader.getRows(), (row) =>
+      Object.fromEntries(names.map((name, i) => [name, row[i]])),
+    );
+  }
+
+  test("first session after an all-null closure identity row lags to the prior SESSION", async () => {
+    const records = await queryRecords([{ ticker: "SPX", date: "2022-05-31" }]);
+    expect(records).toHaveLength(1);
+    // Enrichment-derived close field: Friday's RSI, NOT the identity row's null.
+    expect(Number(records[0].prev_RSI_14)).toBeCloseTo(55.5, 6);
+    // OHLCV close field joined from spot_daily: Friday's close, NOT the holiday's 4148.5.
+    expect(Number(records[0].prev_close)).toBeCloseTo(4158.24, 6);
+  });
+
+  test("requested non-session identity row keeps its output row, priors null", async () => {
+    // Only the LAG input set changes. A requested closure identity row still
+    // returns its row (presence preserved), but it is excluded from the LAG
+    // source set itself, so its prev_* lookups are NULL — there is no
+    // meaningful prior-session value for a day the market was closed.
+    const records = await queryRecords([{ ticker: "SPX", date: "2022-05-30" }]);
+    expect(records).toHaveLength(1);
+    expect(records[0].prev_RSI_14 ?? null).toBeNull();
+    expect(records[0].prev_close ?? null).toBeNull();
+  });
+
+  test("out-of-range dates stay LAG-consumed (bounded-calendar keep-doctrine)", async () => {
+    // 2021-12-26 is a Sunday outside the calendar revision: the calendar has
+    // no opinion there, so the row must keep feeding the lag chain exactly as
+    // before — documented limitation, guarded against over-exclusion.
+    await conn.run(
+      `INSERT INTO market.spot (ticker, date, time, open, high, low, close, bid, ask)
+       VALUES ('SPX', '2021-12-26', '09:30', 99, 102, 98, 101, NULL, NULL)`,
+    );
+    await conn.run(`
+      INSERT INTO market.enriched (ticker, date, RSI_14) VALUES
+        ('SPX', '2021-12-26', 40.0),
+        ('SPX', '2022-01-03', 41.0)
+    `);
+    const records = await queryRecords([{ ticker: "SPX", date: "2022-01-03" }]);
+    expect(records).toHaveLength(1);
+    expect(Number(records[0].prev_RSI_14)).toBeCloseTo(40.0, 6);
   });
 });

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -1339,7 +1339,11 @@ describe("io.spotStore is the canonical OHLCV read path", () => {
     expect(fakeSpot.readDailyBarsCalls).toContain("SPX");
     // Tier 1 must complete (NOT skipped)
     expect(result.tier1.status).toBe("complete");
-    expect(result.rowsEnriched).toBe(60);
+    // 60 weekday bars − 3 XNYS full-day closures in the span (2025-01-09
+    // special closure, 2025-01-20 MLK, 2025-02-17 Washington's Birthday).
+    // The generator emits weekdays only; the enricher's session filter now
+    // drops those three non-session partitions before indicator math.
+    expect(result.rowsEnriched).toBe(57);
     expect(result.enrichedThrough).toBe(spxBars[spxBars.length - 1].date);
   });
 
@@ -1582,5 +1586,174 @@ describe("Enricher indicator units regression", () => {
     // due to the upstream zero-bar cascade). Demand it sit in [0.5, 2.0].
     expect(ratio).toBeGreaterThan(0.5);
     expect(ratio).toBeLessThan(2.0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tier 1 indicator series contains only genuine XNYS sessions
+//
+// The VIX spot feed carries priced full-day holiday partitions. If those
+// partitions enter the rawRows series, "one position back" means "the prior
+// partition": the session after a holiday lags to the holiday's close and
+// every windowed indicator spans the wrong days. The enricher owns this
+// invariant for every OHLCV source — the canonical Parquet spot store
+// filters at the store layer, but the legacy market.spot_daily fallback and
+// table-backed spot stores do not.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Hand-priced SPX daily bars around Memorial Day 2022 (full-day XNYS closure). */
+function memorialDayBars(): Array<{
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}> {
+  const priced = [
+    ["2022-05-26", 4101.9],
+    ["2022-05-27", 4158.24], // last genuine session before the closure
+    ["2022-05-28", 4200.0], // Saturday — never a session
+    ["2022-05-30", 4148.5], // Memorial Day — priced holiday partition
+    ["2022-05-31", 4132.0], // first session after the closure
+    ["2022-06-01", 4102.0],
+  ] as const;
+  return priced.map(([date, close]) => ({
+    date,
+    open: close - 1,
+    high: close + 2,
+    low: close - 2,
+    close,
+  }));
+}
+
+describe("Tier 1 indicator series contains only genuine XNYS sessions", () => {
+  let tmpDir: string;
+  let db: DuckDBInstanceType;
+  let conn: DuckDBConnection;
+
+  beforeEach(async () => {
+    tmpDir = join(
+      tmpdir(),
+      `enricher-sessions-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(join(tmpDir, "market"), { recursive: true });
+    db = await DuckDBInstance.create(":memory:");
+    conn = await db.connect();
+    await conn.run(`ATTACH ':memory:' AS market`);
+    await ensureMutableMarketTables(conn);
+    await ensureMarketDataTables(conn);
+    await conn.run(`
+      CREATE OR REPLACE VIEW market.spot_daily AS
+        SELECT ticker, date,
+               first(open  ORDER BY time) AS open,
+               max(high)                  AS high,
+               min(low)                   AS low,
+               last(close  ORDER BY time) AS close,
+               first(bid   ORDER BY time) AS bid,
+               last(ask    ORDER BY time) AS ask
+        FROM market.spot
+        WHERE time >= '09:30' AND time <= '16:00'
+        GROUP BY ticker, date
+    `);
+  });
+
+  afterEach(() => {
+    try {
+      conn.closeSync();
+    } catch {
+      /* */
+    }
+    try {
+      db.closeSync();
+    } catch {
+      /* */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function readEnrichedRows(ticker: string) {
+    const reader = await conn.runAndReadAll(
+      `SELECT date, Prior_Close FROM market.enriched
+       WHERE ticker = $1 ORDER BY date`,
+      [ticker],
+    );
+    return reader.getRows().map((row) => ({ date: String(row[0]), priorClose: row[1] }));
+  }
+
+  test("io.spotStore path: priced holiday and weekend partitions never enter the indicator series", async () => {
+    const fakeSpot = buildFakeSpotStoreWithDailyBars({ SPX: memorialDayBars() });
+    const io = {
+      spotStore: fakeSpot,
+      watermarkStore: {
+        get: async () => null,
+        upsert: async () => {
+          /* */
+        },
+      },
+    };
+    const result = await runEnrichment(conn, "SPX", { dataDir: tmpDir }, io);
+    expect(result.tier1.status).toBe("complete");
+    expect(result.rowsEnriched).toBe(4); // 6 partitions − holiday − weekend
+
+    const rows = await readEnrichedRows("SPX");
+    const byDate = new Map(rows.map((row) => [row.date, row.priorClose]));
+    expect(byDate.has("2022-05-28")).toBe(false);
+    expect(byDate.has("2022-05-30")).toBe(false);
+    // The session after Memorial Day lags to Friday 05-27's close (4158.24),
+    // not to the holiday partition's own close (4148.5).
+    expect(Number(byDate.get("2022-05-31"))).toBeCloseTo(4158.24, 6);
+    // And the chain continues from genuine sessions only.
+    expect(Number(byDate.get("2022-06-01"))).toBeCloseTo(4132.0, 6);
+  });
+
+  test("legacy market.spot_daily fallback path: non-session rows are still excluded", async () => {
+    for (const bar of memorialDayBars()) {
+      await conn.run(
+        `INSERT INTO market.spot (ticker, date, time, open, high, low, close, bid, ask)
+         VALUES ('SPX', $1, '09:30', $2, $3, $4, $5, NULL, NULL)`,
+        [bar.date, bar.open, bar.high, bar.low, bar.close],
+      );
+    }
+    // No io — runEnrichment reads through the market.spot_daily view, which
+    // has no session filter of its own.
+    const result = await runEnrichment(conn, "SPX", { dataDir: tmpDir });
+    expect(result.tier1.status).toBe("complete");
+    expect(result.rowsEnriched).toBe(4);
+    const rows = await readEnrichedRows("SPX");
+    const byDate = new Map(rows.map((row) => [row.date, row.priorClose]));
+    // Non-session dates never enter the indicator series. They can still
+    // carry all-null enriched identity rows written by Tier 3 timing fields
+    // (which read market.spot directly), so assert on indicator values.
+    expect(byDate.get("2022-05-28")).toBeNull();
+    expect(byDate.get("2022-05-30")).toBeNull();
+    expect(Number(byDate.get("2022-05-31"))).toBeCloseTo(4158.24, 6);
+    expect(Number(byDate.get("2022-06-01"))).toBeCloseTo(4132.0, 6);
+  });
+
+  test("dates outside the calendar revision stay in the series (legacy history preserved)", async () => {
+    const legacyBars = [
+      { date: "2021-12-29", open: 4786.0, high: 4790.0, low: 4770.0, close: 4778.0 },
+      { date: "2021-12-30", open: 4790.0, high: 4800.0, low: 4780.0, close: 4793.54 },
+      { date: "2021-12-31", open: 4795.0, high: 4790.0, low: 4750.0, close: 4766.18 },
+      { date: "2022-01-03", open: 4770.0, high: 4790.0, low: 4750.0, close: 4776.0 },
+    ];
+    const fakeSpot = buildFakeSpotStoreWithDailyBars({ SPX: legacyBars });
+    const io = {
+      spotStore: fakeSpot,
+      watermarkStore: {
+        get: async () => null,
+        upsert: async () => {
+          /* */
+        },
+      },
+    };
+    const result = await runEnrichment(conn, "SPX", { dataDir: tmpDir }, io);
+    expect(result.tier1.status).toBe("complete");
+    expect(result.rowsEnriched).toBe(4); // nothing dropped outside the calendar horizon
+
+    const rows = await readEnrichedRows("SPX");
+    const byDate = new Map(rows.map((row) => [row.date, row.priorClose]));
+    expect(byDate.has("2021-12-31")).toBe(true);
+    expect(Number(byDate.get("2022-01-03"))).toBeCloseTo(4766.18, 6);
   });
 });

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -1756,4 +1756,54 @@ describe("Tier 1 indicator series contains only genuine XNYS sessions", () => {
     expect(byDate.has("2021-12-31")).toBe(true);
     expect(Number(byDate.get("2022-01-03"))).toBeCloseTo(4766.18, 6);
   });
+
+  test("legacy SQL fallback over Hive-partitioned Parquet with DATE partition values completes", async () => {
+    // Gate-rework reproduction: when market.spot_daily is a view over a
+    // Hive-partitioned Parquet tree, DuckDB auto-casts the date partition to
+    // DATE and the fallback's rawRows arrive as DuckDBDateValue objects, not
+    // strings. Enrichment must normalize them at the rawRows boundary and
+    // still exclude the non-session partitions instead of aborting.
+    const hiveDir = join(tmpDir, "spot-hive");
+    await conn.run(`CREATE TEMP TABLE _hive_stage AS SELECT * FROM market.spot WHERE false`);
+    for (const bar of memorialDayBars()) {
+      await conn.run(
+        `INSERT INTO _hive_stage (ticker, date, time, open, high, low, close, bid, ask)
+         VALUES ('SPX', $1, '09:30', $2, $3, $4, $5, NULL, NULL)`,
+        [bar.date, bar.open, bar.high, bar.low, bar.close],
+      );
+    }
+    for (const bar of memorialDayBars()) {
+      const partDir = join(hiveDir, "ticker=SPX", `date=${bar.date}`);
+      mkdirSync(partDir, { recursive: true });
+      await conn.run(
+        `COPY (SELECT time, open, high, low, close, bid, ask FROM _hive_stage WHERE date = '${bar.date}')
+         TO '${partDir}/data.parquet' (FORMAT PARQUET)`,
+      );
+    }
+    await conn.run(`
+      CREATE OR REPLACE VIEW market.spot_daily AS
+        SELECT ticker, date,
+               first(open ORDER BY time) AS open,
+               max(high)                 AS high,
+               min(low)                  AS low,
+               last(close ORDER BY time) AS close,
+               first(bid ORDER BY time)  AS bid,
+               last(ask ORDER BY time)   AS ask
+        FROM read_parquet('${join(hiveDir, "ticker=*", "date=*", "*.parquet")}', hive_partitioning = true)
+        GROUP BY ticker, date
+    `);
+    // Pin the defect shape: the view's date column must be DuckDB DATE.
+    const shape = await conn.runAndReadAll(`SELECT typeof(date) FROM market.spot_daily LIMIT 1`);
+    expect(shape.getRows()[0]?.[0]).toBe("DATE");
+
+    const result = await runEnrichment(conn, "SPX", { dataDir: tmpDir });
+    expect(result.tier1.status).toBe("complete");
+    expect(result.rowsEnriched).toBe(4);
+    const rows = await readEnrichedRows("SPX");
+    const byDate = new Map(rows.map((row) => [row.date, row.priorClose]));
+    expect(byDate.has("2022-05-28")).toBe(false);
+    expect(byDate.has("2022-05-30")).toBe(false);
+    expect(Number(byDate.get("2022-05-31"))).toBeCloseTo(4158.24, 6);
+    expect(Number(byDate.get("2022-06-01"))).toBeCloseTo(4132.0, 6);
+  });
 });

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -1724,6 +1724,15 @@ describe("Tier 1 indicator series contains only genuine XNYS sessions", () => {
     // Non-session dates never enter the indicator series. They can still
     // carry all-null enriched identity rows written by Tier 3 timing fields
     // (which read market.spot directly), so assert on indicator values.
+    // Shape differs between the paths: this legacy fallback keeps row
+    // presence for non-session dates — Tier 3 timing reads market.spot
+    // directly and INSERT OR REPLACEs a row for every date with intraday
+    // bars in range — so 05-28/05-30 exist with NULL Prior_Close and assert
+    // as toBeNull(). The io.spotStore path ("priced holiday and weekend
+    // partitions never enter the indicator series", ~25 lines up) never
+    // mints those rows at all, so it asserts absence with byDate.has(...)
+    // === false instead. Same exclusion contract, different published row
+    // presence.
     expect(byDate.get("2022-05-28")).toBeNull();
     expect(byDate.get("2022-05-30")).toBeNull();
     expect(Number(byDate.get("2022-05-31"))).toBeCloseTo(4158.24, 6);

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -1815,4 +1815,50 @@ describe("Tier 1 indicator series contains only genuine XNYS sessions", () => {
     expect(Number(byDate.get("2022-05-31"))).toBeCloseTo(4158.24, 6);
     expect(Number(byDate.get("2022-06-01"))).toBeCloseTo(4132.0, 6);
   });
+
+  test("DuckDBDateValue day counts far outside the plausible window fail loudly", async () => {
+    const poisonedSpot: FakeSpotStore = {
+      readBars: async () => [],
+      readDailyBars: async (t: string) => [
+        {
+          ticker: t,
+          date: "2022-05-27",
+          time: "09:30",
+          open: 4158.24,
+          high: 4168.22,
+          low: 4152.27,
+          close: 4158.24,
+          volume: 0,
+        },
+        {
+          ticker: t,
+          // {days:N} DuckDBDateValue shape; 500905 days since epoch = 3341-06-07.
+          date: { days: 500905 } as unknown as string,
+          time: "09:30",
+          open: 4132.0,
+          high: 4140.0,
+          low: 4120.0,
+          close: 4132.0,
+          volume: 0,
+        },
+      ],
+      getCoverage: async () => ({
+        earliest: "2022-05-27",
+        latest: "2022-05-27",
+        missingDates: [],
+        totalDates: 1,
+      }),
+      writeBars: async () => {},
+    };
+    const io = {
+      spotStore: poisonedSpot,
+      watermarkStore: {
+        get: async () => null,
+        upsert: async () => {},
+      },
+    };
+    await expect(runEnrichment(conn, "SPX", { dataDir: tmpDir }, io)).rejects.toThrow(
+      /implausible/i,
+    );
+  });
 });


### PR DESCRIPTION
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-2871-enricher-session-lag

fix(mcp-server): enricher indicator series and lookahead-free LAG contain only genuine sessions

## Problem

Tier 1 built `dates/opens/highs/lows/closes` from every row the OHLCV source returned. The
VIX spot feed carries priced market-holiday partitions (32 today). Those rows passed the
all-zero-OHLC defensive guard, entered the arrays, and made "one position back" mean "the
prior partition": the session after a holiday lags `Prior_Close` to the holiday's close, and
every windowed indicator (RSI_14, ATR_Pct, Price_vs_EMA21/SMA50, Realized_Vol_5D/20D,
Return_5D/20D, Consecutive_Days) computes over wrong day sets for all following rows.

Measured on the live plane: `2022-05-31 Prior_Close` 26.54 (a holiday's close) instead of
25.59; `2026-01-20` 18.84 instead of 15.91.

## Fix

Filter `rawRows` against the existing bounded XNYS session calendar
(`isXnysSessionDate`, revision 2022-01-01..2030-12-31) right after the zero-OHLC guard and
before the five arrays are built. Dates outside the supported range stay unfiltered, matching
the existing `isCompleteXnysWindow` doctrine for legacy physical data. Dropped rows are
announced on the operator console, mirroring the adjacent zero-OHLC guard.

This is a correctness fix, not an interface break: no column is added, removed, or renamed;
`Prior_Close` keeps its declared meaning and starts satisfying it.

Additionally, in this commit:

- Legacy fallback robustness: `runEnrichment` normalizes OHLCV row dates to validated
  YYYY-MM-DD strings at the rawRows boundary. When `market.spot_daily` is read over a
  Hive-partitioned Parquet view whose DATE partition values arrive as DuckDBDateValue objects,
  enrichment previously aborted with a TypeError instead of filtering the non-session partition.

- Lookahead-free queries: `buildLookaheadFreeQuery()` now consumes only genuine XNYS sessions in
  the LAG source set (same bounded calendar, 2022-01-01..2030-12-31, as the enricher filter), so
  a lag never lands on an all-null non-session identity row left behind by Tier-3/backfill
  mechanics — the first session after a closure receives Friday's values, not NULL/stale values.
  Published row presence is unchanged; `market.enriched` may still contain all-null identity
  rows, and a requested non-session date returns its row with null priors. Limitation: rows
  dated outside 2022-01-01..2030-12-31 remain LAG-consumed exactly as before — the calendar has
  no opinion there (same doctrine as the enricher filter).

## Scope consequence (read before reviewing numbers)

The same `closes/highs/lows` arrays feed every Tier 1 column. On sources that carry holiday
partitions, values change beyond `Prior_Close`: per-column changed-row counts for a full VIX
re-enrichment (1194 rows, 31 priced non-session partitions) are listed in the work-item
return — headline figures: ATR_Pct/RSI_14/Price_vs_EMA21_Pct/Prior_Range_vs_ATR ~1087–1091
rows, Realized_Vol_20D 576, Return_20D 572, Price_vs_SMA50_Pct 972, Prior_Close/Gap_Pct 62
(31 holiday rows → null + 31 corrected lags), same-row fields 31, ivr/ivp 26. Existing
wrong-valued rows already in enriched stores are not rewritten by this commit; they require a
deliberate re-materialization.

Tier 2 builds a SEPARATE VIX series in `runTier2()` (`market-enricher.ts:986-1123`) rather than
consuming the filtered Tier 1 arrays: ivr/ivp exposure comes from a different source than the
filtered arrays. The canonical `io.spotStore` path supplies session-bounded bars there; the
no-`io.spotStore` fallback still reads `market.spot_daily` for IVR/IVP and context. The
per-column movement table therefore describes Tier 1 outputs plus the separately-sourced
Tier 2 ivr/ivp windows; row PRESENCE in published tables is unchanged by this commit — only
values consumed from the indicator series and the LAG plane change.

On the analysis plane, for each in-range non-session identity row in a ticker's enriched
history exactly one following genuine session changes: its 39 prev_* columns move from NULL or
stale holiday values to the correct prior-session values (~1,200–1,600 prev_* cells on a
holiday-carrying VIX fallback history).

## Tests

- New public-entrypoint coverage: priced holiday and weekend partitions never enter the
  indicator series via the io.spotStore path nor the legacy `market.spot_daily` fallback;
  out-of-calendar legacy dates remain in the series.
- Existing exact-count expectation updated 60 → 57 (three XNYS closures fall inside the
  generated fixture span); declared in the work-item return.
- New: legacy fallback driven through a real Hive-partitioned Parquet view with DATE partition
  values completes and excludes non-session partitions.
- New: buildLookaheadFreeQuery executed over an enriched history containing all-null closure
  identity rows — the following genuine session lags Friday's values, not NULL; requested
  identity rows keep output presence with null priors; out-of-range rows stay LAG-consumed.
- `npm run typecheck`, `npm run build -w packages/mcp-server`,
  `npm test -w packages/mcp-server`: 1919 passed / 0 failed / 0 skipped.
