### PR TITLE
fix(mcp-server): enforce canonical enriched Parquet schemas

### DIFF
--- a/packages/mcp-server/src/db/parquet-writer.ts
+++ b/packages/mcp-server/src/db/parquet-writer.ts
@@ -27,7 +27,10 @@ import type {
   PartitionQualityCounts,
   StoredPartitionCommit,
 } from "../market/provenance/partition-commit-store.ts";
-import { PartitionFilePublicationError } from "../market/provenance/partition-commit-store.ts";
+import {
+  PartitionFilePublicationError,
+  assertCanonicalParquetSchema,
+} from "../market/provenance/partition-commit-store.ts";
 import {
   activePartitionCommitAttempt,
   capturePartitionCommitReceipt,
@@ -281,6 +284,13 @@ export async function writeParquetAtomic(
     await conn.run(
       `COPY "${stagingName}" TO '${tempPath}' (FORMAT PARQUET, COMPRESSION ${compression})`,
     );
+
+    // Inside a partition commit attempt the completed temp sibling must
+    // already match the canonical dataset schema before any fingerprint,
+    // receipt, event, or install step can observe it.
+    if (provenanceAttempt && provenance) {
+      await assertCanonicalParquetSchema(conn, tempPath, provenance.dataset);
+    }
 
     // Re-open the exact completed bytes. Counts and coverage must describe the
     // file being installed, not mutable staging state that merely preceded it.

--- a/packages/mcp-server/src/market/provenance/partition-commit-store.ts
+++ b/packages/mcp-server/src/market/provenance/partition-commit-store.ts
@@ -414,13 +414,18 @@ function canonicalDuckDbType(value: unknown): string {
   return normalized === "REAL" ? "FLOAT" : normalized;
 }
 
-async function inspectCanonicalParquet(
+/**
+ * @internal Single canonical Parquet schema declaration check. Every consumer
+ * (adoption inspection, prepared-file gate inside a commit attempt) verifies
+ * through this assertion so the expected schema exists in exactly one place.
+ */
+export async function assertCanonicalParquetSchema(
   conn: DuckDBConnection,
   filePath: string,
-  identity: PartitionIdentity,
-): Promise<{ rows: number; coverage: LogicalCoverage }> {
-  const expectedSchema = CANONICAL_PARQUET_SCHEMAS[identity.dataset];
-  if (!expectedSchema) throw new TypeError(`No canonical Parquet schema for ${identity.dataset}`);
+  dataset: string,
+): Promise<void> {
+  const expectedSchema = CANONICAL_PARQUET_SCHEMAS[dataset];
+  if (!expectedSchema) throw new TypeError(`No canonical Parquet schema for ${dataset}`);
   const source = `read_parquet('${escapeSqlLiteral(filePath)}', hive_partitioning=false)`;
   const described = await conn.runAndReadAll(`DESCRIBE SELECT * FROM ${source}`);
   const schema = described
@@ -428,9 +433,18 @@ async function inspectCanonicalParquet(
     .map((row) => [String(row[0]), canonicalDuckDbType(row[1])] as const);
   if (canonicalJsonBytes(schema).compare(canonicalJsonBytes(expectedSchema)) !== 0) {
     throw new Error(
-      `Existing partition Parquet schema does not match revision 1: ${JSON.stringify({ observed: schema, expected: expectedSchema })}`,
+      `Canonical Parquet schema does not match revision 1: ${JSON.stringify({ dataset, observed: schema, expected: expectedSchema })}`,
     );
   }
+}
+
+async function inspectCanonicalParquet(
+  conn: DuckDBConnection,
+  filePath: string,
+  identity: PartitionIdentity,
+): Promise<{ rows: number; coverage: LogicalCoverage }> {
+  await assertCanonicalParquetSchema(conn, filePath, identity.dataset);
+  const source = `read_parquet('${escapeSqlLiteral(filePath)}', hive_partitioning=false)`;
   const definition = canonicalPartitionDataset(identity.dataset) as NonNullable<
     ReturnType<typeof canonicalPartitionDataset>
   >;

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -470,6 +470,7 @@ export type {
 } from "./market/provenance/index.ts";
 export { finalizeCanonicalMarketDataCutoff } from "./market/provenance/canonical-market-resolver.ts";
 export { publishRefreshCompletionAuthority } from "./market/provenance/partition-commit-store.ts";
+export { assertCanonicalParquetSchema } from "./market/provenance/partition-commit-store.ts";
 
 // Export json-store utility for unit testing
 export {

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -958,7 +958,7 @@ async function flushEnrichedToParquet(
         ticker,
         date,
         selectQuery:
-          `SELECT ticker, date, ${enrichedColList} FROM "${tables.dailyTable}" ` +
+          `SELECT ticker, CAST(date AS VARCHAR) AS date, ${enrichedColList} FROM "${tables.dailyTable}" ` +
           `WHERE ticker = '${ticker}' AND date = '${date}'`,
         quality: { kind: "writer-input-complete" },
       });
@@ -984,7 +984,7 @@ async function flushEnrichedToParquet(
         dataDir,
         date,
         selectQuery:
-          `SELECT date, Vol_Regime, Term_Structure_State, Trend_Direction, ` +
+          `SELECT CAST(date AS VARCHAR) AS date, Vol_Regime, Term_Structure_State, Trend_Direction, ` +
           `VIX_Spike_Pct, VIX_Gap_Pct FROM "${tables.dateContextTable}" WHERE date = '${date}'`,
         quality: { kind: "writer-input-complete" },
       });

--- a/packages/mcp-server/tests/unit/market-datasets.test.ts
+++ b/packages/mcp-server/tests/unit/market-datasets.test.ts
@@ -46,6 +46,39 @@ let tmpDir: string; // serves as dataDir
 let db: DuckDBInstance;
 let conn: DuckDBConnection;
 
+// Exact revision-1 canonical enriched projection. Attempt-scoped writes are
+// schema-gated, so prepared fixtures must publish this shape.
+const CANONICAL_ENRICHED_SELECT = `SELECT 'SPX'::VARCHAR AS ticker,
+  '2025-01-06'::VARCHAR AS date,
+  NULL::DOUBLE AS Prior_Close,
+  NULL::DOUBLE AS Gap_Pct,
+  NULL::DOUBLE AS ATR_Pct,
+  NULL::DOUBLE AS RSI_14,
+  NULL::DOUBLE AS Price_vs_EMA21_Pct,
+  NULL::DOUBLE AS Price_vs_SMA50_Pct,
+  NULL::DOUBLE AS Realized_Vol_5D,
+  NULL::DOUBLE AS Realized_Vol_20D,
+  NULL::DOUBLE AS Return_5D,
+  NULL::DOUBLE AS Return_20D,
+  NULL::DOUBLE AS Intraday_Range_Pct,
+  NULL::DOUBLE AS Intraday_Return_Pct,
+  NULL::DOUBLE AS Close_Position_In_Range,
+  NULL::INTEGER AS Gap_Filled,
+  NULL::INTEGER AS Consecutive_Days,
+  NULL::DOUBLE AS Prev_Return_Pct,
+  NULL::DOUBLE AS Prior_Range_vs_ATR,
+  NULL::DOUBLE AS High_Time,
+  NULL::DOUBLE AS Low_Time,
+  NULL::INTEGER AS High_Before_Low,
+  NULL::INTEGER AS Reversal_Type,
+  NULL::DOUBLE AS Opening_Drive_Strength,
+  NULL::DOUBLE AS Intraday_Realized_Vol,
+  NULL::INTEGER AS Day_of_Week,
+  NULL::INTEGER AS Month,
+  NULL::INTEGER AS Is_Opex,
+  NULL::DOUBLE AS ivr,
+  NULL::DOUBLE AS ivp
+FROM src`;
 beforeEach(async () => {
   tmpDir = join(
     tmpdir(),
@@ -251,7 +284,16 @@ describe("writeSpotPartition — path resolution", () => {
           dataDir: tmpDir,
           ticker: "SPX",
           date: "2025-01-06",
-          selectQuery: "SELECT *, '2025-01-06' AS date FROM src",
+          selectQuery: `SELECT 'SPX'::VARCHAR AS ticker,
+                 '2025-01-06'::VARCHAR AS date,
+                 '09:30'::VARCHAR AS time,
+                 225.0::DOUBLE AS open,
+                 226.0::DOUBLE AS high,
+                 224.0::DOUBLE AS low,
+                 225.5::DOUBLE AS close,
+                 NULL::DOUBLE AS bid,
+                 NULL::DOUBLE AS ask
+               FROM src`,
           quality: { inputRows: 3, droppedRows: 0 },
         }),
     );
@@ -439,7 +481,7 @@ describe("writeEnrichedTickerPartition — bounded partitioning", () => {
           dataDir: tmpDir,
           ticker: "SPX",
           date: "2025-01-06",
-          selectQuery: "SELECT 'SPX' ticker, '2025-01-06' date, id, label FROM src",
+          selectQuery: CANONICAL_ENRICHED_SELECT,
           quality: { kind: "writer-input-complete" },
         }),
     );

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -38,7 +38,7 @@ import {
 } from "../../src/test-exports.ts";
 import type { DuckDBConnection, DuckDBInstance as DuckDBInstanceType } from "@duckdb/node-api";
 import { DuckDBInstance } from "@duckdb/node-api";
-import { existsSync, mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -1860,5 +1860,152 @@ describe("Tier 1 indicator series contains only genuine XNYS sessions", () => {
     await expect(runEnrichment(conn, "SPX", { dataDir: tmpDir }, io)).rejects.toThrow(
       /implausible/i,
     );
+  });
+});
+// =============================================================================
+// Canonical Parquet flush schemas
+//
+// A re-flush seeds its working tables by reading published enriched/ slices
+// back with hive_partitioning=true; DuckDB types that synthesized date column
+// as DATE. Both publication projections must CAST it back to VARCHAR so every
+// published file keeps the revision-1 canonical schema.
+// =============================================================================
+
+const ENRICHED_TICKER_SCHEMA: Array<[string, string]> = [
+  ["ticker", "VARCHAR"],
+  ["date", "VARCHAR"],
+  ["Prior_Close", "DOUBLE"],
+  ["Gap_Pct", "DOUBLE"],
+  ["ATR_Pct", "DOUBLE"],
+  ["RSI_14", "DOUBLE"],
+  ["Price_vs_EMA21_Pct", "DOUBLE"],
+  ["Price_vs_SMA50_Pct", "DOUBLE"],
+  ["Realized_Vol_5D", "DOUBLE"],
+  ["Realized_Vol_20D", "DOUBLE"],
+  ["Return_5D", "DOUBLE"],
+  ["Return_20D", "DOUBLE"],
+  ["Intraday_Range_Pct", "DOUBLE"],
+  ["Intraday_Return_Pct", "DOUBLE"],
+  ["Close_Position_In_Range", "DOUBLE"],
+  ["Gap_Filled", "INTEGER"],
+  ["Consecutive_Days", "INTEGER"],
+  ["Prev_Return_Pct", "DOUBLE"],
+  ["Prior_Range_vs_ATR", "DOUBLE"],
+  ["High_Time", "DOUBLE"],
+  ["Low_Time", "DOUBLE"],
+  ["High_Before_Low", "INTEGER"],
+  ["Reversal_Type", "INTEGER"],
+  ["Opening_Drive_Strength", "DOUBLE"],
+  ["Intraday_Realized_Vol", "DOUBLE"],
+  ["Day_of_Week", "INTEGER"],
+  ["Month", "INTEGER"],
+  ["Is_Opex", "INTEGER"],
+  ["ivr", "DOUBLE"],
+  ["ivp", "DOUBLE"],
+];
+
+const ENRICHED_CONTEXT_SCHEMA: Array<[string, string]> = [
+  ["date", "VARCHAR"],
+  ["Vol_Regime", "INTEGER"],
+  ["Term_Structure_State", "INTEGER"],
+  ["Trend_Direction", "VARCHAR"],
+  ["VIX_Spike_Pct", "DOUBLE"],
+  ["VIX_Gap_Pct", "DOUBLE"],
+];
+
+describe("parquet flush publishes canonical VARCHAR date schemas", () => {
+  let tmpDir: string;
+  let db: DuckDBInstanceType;
+  let conn: DuckDBConnection;
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `enricher-schema-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(tmpDir, "market"), { recursive: true });
+    db = await DuckDBInstance.create(":memory:");
+    conn = await db.connect();
+    await conn.run(`ATTACH ':memory:' AS market`);
+    await ensureMutableMarketTables(conn);
+    await ensureMarketDataTables(conn);
+    await conn.run(`
+      CREATE OR REPLACE VIEW market.spot_daily AS
+        SELECT ticker, date,
+               first(open  ORDER BY time) AS open,
+               max(high)                  AS high,
+               min(low)                   AS low,
+               last(close ORDER BY time)  AS close,
+               first(bid   ORDER BY time) AS bid,
+               last(ask    ORDER BY time) AS ask
+        FROM market.spot
+        WHERE time >= '09:30' AND time <= '16:00'
+        GROUP BY ticker, date
+    `);
+  });
+
+  afterEach(() => {
+    try {
+      conn.closeSync();
+    } catch {
+      /* */
+    }
+    try {
+      db.closeSync();
+    } catch {
+      /* */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const describeFile = async (filePath: string): Promise<Array<[string, string]>> => {
+    const reader = await conn.runAndReadAll(
+      `DESCRIBE SELECT * FROM read_parquet('${filePath.replaceAll("'", "''")}', hive_partitioning=false)`,
+    );
+    return reader.getRows().map((row) => [String(row[0]), String(row[1])]);
+  };
+
+  test("bounded hive-seeded ticker and context flushes publish exact revision-1 VARCHAR date schemas", async () => {
+    const dates = ["2025-01-06", "2025-01-07", "2025-01-08"];
+    await seedDailyFixture(conn, "SPX", dates);
+    await runEnrichment(conn, "SPX", { dataDir: tmpDir, parquetMode: true });
+
+    // Seed one canonical context partition so the bounded second pass
+    // hive-seeds its context working table from it (synthesizing DATE from
+    // the path key). The real flush projection must cast date back to VARCHAR.
+    const contextDir = join(tmpDir, "market", "enriched", "context", "date=2025-01-07");
+    mkdirSync(contextDir, { recursive: true });
+    await conn.run(`
+      COPY (
+        SELECT '2025-01-07'::VARCHAR AS date,
+               3::INTEGER AS Vol_Regime,
+               1::INTEGER AS Term_Structure_State,
+               'flat'::VARCHAR AS Trend_Direction,
+               5.0::DOUBLE AS VIX_Spike_Pct,
+               2.0::DOUBLE AS VIX_Gap_Pct
+      ) TO '${join(contextDir, "data.parquet")}' (FORMAT PARQUET)
+    `);
+
+    // The second bounded pass seeds its working tables by reading the just-
+    // published slices back with hive_partitioning=true, so `date` arrives as
+    // DuckDB DATE. Without the projection cast, republication would emit DATE.
+
+    const enrichedDir = join(tmpDir, "market", "enriched");
+    const tickerDates = readdirSync(join(enrichedDir, "ticker=SPX")).filter((entry) =>
+      entry.startsWith("date="),
+    );
+    expect(tickerDates.length).toBeGreaterThan(0);
+    for (const entry of tickerDates) {
+      expect(await describeFile(join(enrichedDir, "ticker=SPX", entry, "data.parquet"))).toEqual(
+        ENRICHED_TICKER_SCHEMA,
+      );
+    }
+
+    const contextDates = readdirSync(join(enrichedDir, "context")).filter((entry) =>
+      entry.startsWith("date="),
+    );
+    expect(contextDates.length).toBeGreaterThan(0);
+    for (const entry of contextDates) {
+      expect(await describeFile(join(enrichedDir, "context", entry, "data.parquet"))).toEqual(
+        ENRICHED_CONTEXT_SCHEMA,
+      );
+    }
   });
 });

--- a/packages/mcp-server/tests/unit/market-provenance.test.ts
+++ b/packages/mcp-server/tests/unit/market-provenance.test.ts
@@ -27,6 +27,7 @@ import {
   adoptCanonicalHistoricalInputClosure,
   addressBytes,
   addressCanonicalJson,
+  assertCanonicalParquetSchema,
   canonicalJson,
   parseCanonicalJsonAddress,
   publishCanonicalMarketResolverRegistry,
@@ -350,6 +351,59 @@ describe("market-data provenance foundation", () => {
         expect(adopted.receipts).toHaveLength(1);
         await expect(store.inspectPartition(identity)).resolves.toMatchObject({ status: "match" });
         expect(existsSync(join(rootDir, ".provenance", "refresh-completions"))).toBe(false);
+      } finally {
+        conn.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    it("adoption accepts VARCHAR dates and refuses DATE through the shared schema assertion", async () => {
+      const store = new FilePartitionCommitStore(rootDir);
+      const instance = await DuckDBInstance.create(":memory:");
+      const conn = await instance.connect();
+      try {
+        const varcharPath = join(externalDir, "varchar-date.parquet");
+        await conn.run(`
+          COPY (
+            SELECT 'IWM'::VARCHAR AS ticker,
+                   '2026-07-20'::VARCHAR AS date,
+                   '09:30'::VARCHAR AS time,
+                   225.0::DOUBLE AS open,
+                   226.0::DOUBLE AS high,
+                   224.0::DOUBLE AS low,
+                   225.5::DOUBLE AS close,
+                   NULL::DOUBLE AS bid,
+                   NULL::DOUBLE AS ask
+          ) TO '${varcharPath}' (FORMAT PARQUET)
+        `);
+        await expect(
+          assertCanonicalParquetSchema(conn, varcharPath, "spot"),
+        ).resolves.toBeUndefined();
+
+        const targetPath = targetFor(identity.partition);
+        mkdirSync(dirname(targetPath), { recursive: true });
+        await conn.run(`
+          COPY (
+            SELECT 'IWM'::VARCHAR AS ticker,
+                   DATE '2026-07-20' AS date,
+                   '09:30'::VARCHAR AS time,
+                   225.0::DOUBLE AS open,
+                   226.0::DOUBLE AS high,
+                   224.0::DOUBLE AS low,
+                   225.5::DOUBLE AS close,
+                   NULL::DOUBLE AS bid,
+                   NULL::DOUBLE AS ask
+          ) TO '${targetPath.replaceAll("'", "''")}' (FORMAT PARQUET)
+        `);
+        await expect(assertCanonicalParquetSchema(conn, targetPath, "spot")).rejects.toThrow(
+          /Canonical Parquet schema does not match revision 1.*"dataset":"spot".*"DATE"/,
+        );
+
+        const before = lstatSync(targetPath);
+        await expect(
+          store[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, identity),
+        ).rejects.toThrow(/schema does not match revision 1/);
+        expect(lstatSync(targetPath).ino).toBe(before.ino);
       } finally {
         conn.closeSync();
         instance.closeSync();

--- a/packages/mcp-server/tests/unit/market-provenance.test.ts
+++ b/packages/mcp-server/tests/unit/market-provenance.test.ts
@@ -400,9 +400,9 @@ describe("market-data provenance foundation", () => {
         );
 
         const before = lstatSync(targetPath);
-        await expect(
-          store[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, identity),
-        ).rejects.toThrow(/schema does not match revision 1/);
+        await expect(store[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, identity)).rejects.toThrow(
+          /schema does not match revision 1/,
+        );
         expect(lstatSync(targetPath).ino).toBe(before.ino);
       } finally {
         conn.closeSync();

--- a/packages/mcp-server/tests/unit/parquet-spot-store-zero-guard.test.ts
+++ b/packages/mcp-server/tests/unit/parquet-spot-store-zero-guard.test.ts
@@ -125,8 +125,8 @@ describe("ParquetSpotStore writeBars zero/weekend guard", () => {
         store.writeFromSelect(
           { ticker: "SPX", date: "2025-01-07" },
           `SELECT 'SPX' AS ticker, '2025-01-07' AS date, '09:30' AS time,
-                  100.0 AS open, 101.0 AS high, 99.0 AS low, 100.5 AS close,
-                  NULL::DOUBLE AS bid, NULL::DOUBLE AS ask`,
+                  100.0::DOUBLE AS open, 101.0::DOUBLE AS high, 99.0::DOUBLE AS low,
+                  100.5::DOUBLE AS close, NULL::DOUBLE AS bid, NULL::DOUBLE AS ask`,
         ),
     );
 

--- a/packages/mcp-server/tests/unit/parquet-writer.test.ts
+++ b/packages/mcp-server/tests/unit/parquet-writer.test.ts
@@ -6,9 +6,9 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, rmSync, existsSync } from "fs";
+import { mkdirSync, readFileSync, renameSync, rmSync, existsSync, writeFileSync, readdirSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import { DuckDBInstance, DuckDBConnection } from "@duckdb/node-api";
 import {
   isParquetMode,
@@ -95,6 +95,21 @@ describe("parquet-writer", () => {
       }
       rmSync(tmpDir, { recursive: true, force: true });
     });
+
+    // Exact revision-1 canonical spot projection. Attempt-scoped writes are
+    // schema-gated, so every prepared fixture must publish this shape.
+    const canonicalSpotSelect = (dateExpression: string, from = "") => {
+      const source = from ? `\n             FROM ${from}` : "";
+      return `SELECT 'IWM'::VARCHAR AS ticker,
+             ${dateExpression} AS date,
+             '09:30'::VARCHAR AS time,
+             225.0::DOUBLE AS open,
+             226.0::DOUBLE AS high,
+             224.0::DOUBLE AS low,
+             225.5::DOUBLE AS close,
+             NULL::DOUBLE AS bid,
+             NULL::DOUBLE AS ask${source}`;
+    };
 
     it("writes a Parquet file with ZSTD compression and returns rowCount", async () => {
       // Create test data in DuckDB
@@ -189,7 +204,7 @@ describe("parquet-writer", () => {
 
     it("records the exact committed hash, bytes, and rows through an attempt scope", async () => {
       await conn.run(
-        `CREATE TEMP TABLE exact_data AS SELECT id, '2026-07-20' AS date FROM range(0, 7) t(id)`,
+        `CREATE TEMP TABLE exact_data AS ${canonicalSpotSelect("'2026-07-20'::VARCHAR", "range(0, 7) t(id)")}`,
       );
       const targetPath = join(
         tmpDir,
@@ -239,7 +254,7 @@ describe("parquet-writer", () => {
 
     it("snapshots mutable provenance before the first asynchronous write step", async () => {
       await conn.run(
-        `CREATE TEMP TABLE mutable_provenance AS SELECT 1 AS id, '2026-07-27' AS date`,
+        `CREATE TEMP TABLE mutable_provenance AS ${canonicalSpotSelect("'2026-07-27'::VARCHAR")}`,
       );
       const targetPath = join(
         tmpDir,
@@ -290,7 +305,9 @@ describe("parquet-writer", () => {
     });
 
     it("leaves a detectable orphan when receipt recording fails after publish", async () => {
-      await conn.run(`CREATE TEMP TABLE orphan_data AS SELECT 1 AS id, '2026-07-21' AS date`);
+      await conn.run(
+        `CREATE TEMP TABLE orphan_data AS ${canonicalSpotSelect("'2026-07-21'::VARCHAR")}`,
+      );
       const targetPath = join(
         tmpDir,
         "market",
@@ -341,7 +358,9 @@ describe("parquet-writer", () => {
     });
 
     it("refuses to publish provenance without explicit quality counts", async () => {
-      await conn.run(`CREATE TEMP TABLE no_quality AS SELECT 1 AS id, '2026-07-22' AS date`);
+      await conn.run(
+        `CREATE TEMP TABLE no_quality AS ${canonicalSpotSelect("'2026-07-22'::VARCHAR")}`,
+      );
       const targetPath = join(
         tmpDir,
         "market",
@@ -374,7 +393,7 @@ describe("parquet-writer", () => {
       const store = new FilePartitionCommitStore(join(tmpDir, "market"));
       const writeBad = async (dateExpression: string, partitionDate: string) => {
         await conn.run(
-          `CREATE OR REPLACE TEMP TABLE bad_coverage AS SELECT 1 AS id, ${dateExpression} AS date`,
+          `CREATE OR REPLACE TEMP TABLE bad_coverage AS ${canonicalSpotSelect(dateExpression)}`,
         );
         const targetPath = join(
           tmpDir,
@@ -412,6 +431,103 @@ describe("parquet-writer", () => {
       expect(existsSync(wrongDate.targetPath)).toBe(false);
     });
 
+    // Full canonical `enriched` schema with a caller-controlled date
+    // expression, so the same projection can be published as VARCHAR
+    // (canonical) or DATE (defect shape).
+    const enrichedSelect = (dateExpression: string) => `
+      SELECT 'IWM'::VARCHAR AS ticker,
+             ${dateExpression} AS date,
+             NULL::DOUBLE AS Prior_Close,
+             NULL::DOUBLE AS Gap_Pct,
+             NULL::DOUBLE AS ATR_Pct,
+             NULL::DOUBLE AS RSI_14,
+             NULL::DOUBLE AS Price_vs_EMA21_Pct,
+             NULL::DOUBLE AS Price_vs_SMA50_Pct,
+             NULL::DOUBLE AS Realized_Vol_5D,
+             NULL::DOUBLE AS Realized_Vol_20D,
+             NULL::DOUBLE AS Return_5D,
+             NULL::DOUBLE AS Return_20D,
+             NULL::DOUBLE AS Intraday_Range_Pct,
+             NULL::DOUBLE AS Intraday_Return_Pct,
+             NULL::DOUBLE AS Close_Position_In_Range,
+             NULL::INTEGER AS Gap_Filled,
+             NULL::INTEGER AS Consecutive_Days,
+             NULL::DOUBLE AS Prev_Return_Pct,
+             NULL::DOUBLE AS Prior_Range_vs_ATR,
+             NULL::DOUBLE AS High_Time,
+             NULL::DOUBLE AS Low_Time,
+             NULL::INTEGER AS High_Before_Low,
+             NULL::INTEGER AS Reversal_Type,
+             NULL::DOUBLE AS Opening_Drive_Strength,
+             NULL::DOUBLE AS Intraday_Realized_Vol,
+             NULL::INTEGER AS Day_of_Week,
+             NULL::INTEGER AS Month,
+             NULL::INTEGER AS Is_Opex,
+             NULL::DOUBLE AS ivr,
+             NULL::DOUBLE AS ivp
+    `;
+    const enrichedProvenance = {
+      dataset: "enriched",
+      partition: { ticker: "IWM", date: "2026-07-20" },
+      schemaRevision: 1,
+      relativePath: "enriched/ticker=IWM/date=2026-07-20/data.parquet",
+      coverage: { kind: "prepared-date-range" as const, column: "date" },
+      quality: { inputRows: 1, droppedRows: 0 },
+    };
+
+    it("accepts a canonical VARCHAR-date prepared enriched partition through an attempt", async () => {
+      const store = new FilePartitionCommitStore(join(tmpDir, "market"));
+      const targetPath = join(
+        tmpDir,
+        "market",
+        "enriched",
+        "ticker=IWM",
+        "date=2026-07-20",
+        "data.parquet",
+      );
+
+      const attempt = await runPartitionCommitAttempt(
+        { attemptId: "varchar-enriched", recorder: store },
+        () =>
+          writeParquetAtomic(conn, {
+            targetPath,
+            selectQuery: enrichedSelect("'2026-07-20'::VARCHAR"),
+            provenance: enrichedProvenance,
+          }),
+      );
+
+      expect(attempt.receipts).toHaveLength(1);
+      expect(existsSync(targetPath)).toBe(true);
+    });
+
+    it("refuses a DATE-typed prepared enriched partition before install, receipt, or event", async () => {
+      const store = new FilePartitionCommitStore(join(tmpDir, "market"));
+      const targetPath = join(
+        tmpDir,
+        "market",
+        "enriched",
+        "ticker=IWM",
+        "date=2026-07-20",
+        "data.parquet",
+      );
+      mkdirSync(dirname(targetPath), { recursive: true });
+      const baseline = Buffer.from("existing-canonical-target");
+      writeFileSync(targetPath, baseline);
+
+      await expect(
+        runPartitionCommitAttempt({ attemptId: "date-typed-enriched", recorder: store }, () =>
+          writeParquetAtomic(conn, {
+            targetPath,
+            selectQuery: enrichedSelect("DATE '2026-07-20'"),
+            provenance: enrichedProvenance,
+          }),
+        ),
+      ).rejects.toThrow(/Canonical Parquet schema does not match revision 1/);
+
+      expect(readFileSync(targetPath)).toEqual(baseline);
+      expect(readdirSync(dirname(targetPath)).filter((name) => name.includes(".tmp-"))).toEqual([]);
+    });
+
     it("returns verified frozen receipts in deterministic tuple order with retries deduplicated", async () => {
       const store = new FilePartitionCommitStore(join(tmpDir, "market"));
       const writeDate = async (date: string) => {
@@ -425,7 +541,7 @@ describe("parquet-writer", () => {
         );
         return writeParquetAtomic(conn, {
           targetPath,
-          selectQuery: `SELECT 1 AS id, '${date}' AS date`,
+          selectQuery: canonicalSpotSelect(`'${date}'::VARCHAR`),
           provenance: {
             dataset: "spot",
             partition: { ticker: "IWM", date },

--- a/packages/mcp-server/tests/unit/parquet-writer.test.ts
+++ b/packages/mcp-server/tests/unit/parquet-writer.test.ts
@@ -6,7 +6,15 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, rmSync, existsSync, writeFileSync, readdirSync } from "fs";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  readdirSync,
+} from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { DuckDBInstance, DuckDBConnection } from "@duckdb/node-api";


### PR DESCRIPTION
Fixes tradeblocks-org/enterprise#3045.

## Problem

Hive-seeded enriched working tables can expose `date` as DuckDB `DATE`. The enriched flush copied that physical type into canonical Parquet while revision-1 receipts declared `date VARCHAR`. The attempt writer also trusted the producer projection instead of verifying the completed temp file.

## Change

- Cast `date` to `VARCHAR` in both enriched ticker and context flush projections.
- Extract one internal `assertCanonicalParquetSchema` backed by the existing canonical schema table.
- Run that assertion on every attempt-scoped temp Parquet before coverage inspection, fingerprinting, receipt/event capture, or target install.
- Route historical adoption inspection through the same assertion.
- Preserve legacy non-attempt writes unchanged.

Schema mismatch fails loud with dataset/observed/expected, removes the temp sibling, emits no receipt/event, and leaves any existing target untouched.

## Verification

- Node 24 MCP package build: passed.
- Focused changed-contract suites: 3 suites, 164 passed, 0 failed, 0 skipped.
- Worf exact-head gate at `8ef109c34704988d5fb4a6c6a1f15496d123b197`: CLEAR (PASS).