### PR TITLE
#3245 ignore the receiver-owned fleet-mail mailbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ packages/mcp-server/data/
 .worktrees/
 .claude/worktrees/
 
+# Receiver-owned transient pointer mailbox, armed by `fleet-mail arm` inside a seat or
+# launched-session worktree (enterprise#3245). Measured: an untracked non-ignored file makes
+# `git worktree remove` fail with exit 128, so an unignored mailbox blocks worktree teardown.
+.fleet-inbox/
+
 # General ignores
 .DS_Store
 *.pem


### PR DESCRIPTION
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-3245-fleet-inbox-ignore

## Summary

Ignore the receiver-owned `.fleet-inbox/` transient mailbox so it cannot become an untracked
worktree-retirement blocker. One rule plus its annotation in this repository's root `.gitignore`;
nothing else changes.

**PR 3 of 7 in one rollout.** The scope claim below is fleet-wide; this diff is deliberately this
repository only. Companion PRs, all on branch `romeo/3245-fleet-inbox-ignore`:

- `captains-log` — tradeblocks-org/captains-log#223
- `memory-alpha` — tradeblocks-org/memory-alpha#378
- `tradeblocks` — tradeblocks-org/tradeblocks#437
- `daystrom` — tradeblocks-org/daystrom#179
- `enterprise-console` — tradeblocks-org/enterprise-console#396
- `holodeck` — tradeblocks-org/holodeck#302
- `tastytrade-mcp` — tradeblocks-org/tastytrade-mcp#17

A reviewer holding only this PR cannot verify a fleet-wide claim, so the set is named rather than
asserted.

## Why the rule is load-bearing — measured, not theoretical

`fleet-mail arm` creates a receiver-owned mailbox at `.fleet-inbox/` **inside** the worktree it arms,
and arming is a hard launch precondition — so every repository that hosts a seat or launched-session
worktree acquires that directory. It was gitignored in `utopia-planitia` and `enterprise` only.

An untracked **non-ignored** file makes `git worktree remove` fail with exit 128; a gitignored one
lets it succeed with exit 0. Established on tradeblocks-org/enterprise#3160 by hitting it: retiring a
seat worktree in `captains-log` failed with `contains modified or untracked files, use --force to
delete it`, and the sole offender was `.fleet-inbox/.agent` — the seat's own mailbox binding. Every
repo missing the rule accumulates worktrees that refuse to retire, and the tempting remedy
(`--force`) is a destructive shortcut past a mailbox nobody read.

## Verification

**In this repository, on this branch** — with `.fleet-inbox/.agent` planted in the worktree:

```
$ git check-ignore -v .fleet-inbox/.agent
.gitignore:17:.fleet-inbox/	.fleet-inbox/.agent

$ git status --porcelain
(empty)
```

Run per repository, not inferred from a sibling. The diff against `origin/master` touches
`.gitignore` and nothing else, in one commit.

**The retirement controls** were run once, in `captains-log`, because the mechanism being proven is
git's own and is identical everywhere:

```
# rule present, worktree holding a planted .fleet-inbox/.agent
$ git worktree remove /var/tmp/3245-captains-log-ignore-positive
(exit 0)

# same tree at the base commit, rule absent
$ git worktree remove /var/tmp/3245-captains-log-ignore-negative
fatal: '...' contains modified or untracked files, use --force to delete it
(exit 128)
```

No `--force` removal was used anywhere.

## Scope, and the durable half

Rolled out to every governed fleet repository with a local clone rather than an enumerated
"seat-hosting" subset: that set grows whenever a new repo gets crew work, so the classification decays
exactly the way this missing rule already did, and one ignore rule in a repo that never hosts a seat
costs nothing.

**The recurrence guard is tracked, not informal.** A per-repo one-liner rolled out by hand is the
convention that decays, so the producer announces the problem: `fleet-mail arm` — the single code path
that creates the directory — tests the target worktree with `git check-ignore` and emits a named,
non-fatal advisory when the mailbox will be visible to git, and the launchers surface it in the session
bootstrap. That work is in flight in `utopia-planitia` under the same card, and
**tradeblocks-org/enterprise#3245 stays open until it lands** — this rollout does not close it. Nothing
here depends on it; it exists so a *new* repo cannot repeat this silently.

Card: tradeblocks-org/enterprise#3245
